### PR TITLE
remove rasterio from requirements

### DIFF
--- a/docs/examples/stac_search.ipynb
+++ b/docs/examples/stac_search.ipynb
@@ -25,12 +25,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pystac_client\n",
     "import rasterio\n",
+    "from rasterio.session import AWSSession\n",
     "from rasterio.plot import show\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +118,9 @@
     "# fetch the item URI and open it with rasterio\n",
     "fig, ax = plt.subplots()\n",
     "\n",
-    "with rasterio.Env(session=client.session) as env:\n",
+    "rasterio_session = AWSSession(client.session)\n",
+    "\n",
+    "with rasterio.Env(session=rasterio_session) as env:\n",
     "    for item in items:\n",
     "        asset = item.assets[\"INT\"]\n",
     "        with rasterio.open(asset.href) as src:\n",

--- a/prescient_sdk/client.py
+++ b/prescient_sdk/client.py
@@ -4,7 +4,6 @@ import urllib.parse
 
 import msal
 import boto3
-from rasterio.session import AWSSession
 
 from prescient_sdk.config import Settings
 
@@ -192,14 +191,14 @@ class PrescientClient:
         return self._aws_credentials
     
     @property
-    def session(self) -> AWSSession:
+    def session(self) -> boto3.Session:
         """
-        Get an AWS session to be used when authenticating rasterio
+        Get an AWS session for authenticating to the bucket
 
         Returns:
-            AWSSession: Rasterio AWS session
+            Session: boto3 Session object
         """
-        return AWSSession(
+        return boto3.Session(
             aws_access_key_id=self.aws_credentials["AccessKeyId"], 
             aws_secret_access_key=self.aws_credentials["SecretAccessKey"], 
             aws_session_token=self.aws_credentials["SessionToken"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "boto3>=1.35.19",
     "msal>=1.31.0",
     "pydantic-settings>=2.5.2",
-    "rasterio>=1.3.11",
 ]
 
 [project.urls]
@@ -27,6 +26,7 @@ dev-dependencies = [
   "pytest-mock>=3.14.0",
   "matplotlib>=3.9.2",
   "jupyter-book>=1.0.2",
+  "rasterio>=1.3.11",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1868,13 +1868,12 @@ wheels = [
 
 [[package]]
 name = "prescient-sdk"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "msal" },
     { name = "pydantic-settings" },
-    { name = "rasterio" },
 ]
 
 [package.dev-dependencies]
@@ -1886,6 +1885,7 @@ dev = [
     { name = "pystac-client" },
     { name = "pytest" },
     { name = "pytest-mock" },
+    { name = "rasterio" },
     { name = "ruff" },
 ]
 
@@ -1894,7 +1894,6 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.35.19" },
     { name = "msal", specifier = ">=1.31.0" },
     { name = "pydantic-settings", specifier = ">=2.5.2" },
-    { name = "rasterio", specifier = ">=1.3.11" },
 ]
 
 [package.metadata.requires-dev]
@@ -1906,6 +1905,7 @@ dev = [
     { name = "pystac-client", specifier = ">=0.7.6" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "rasterio", specifier = ">=1.3.11" },
     { name = "ruff", specifier = ">=0.6.5" },
 ]
 


### PR DESCRIPTION
Closes #10 

This returns a boto3 Session from the client instead of a rasterio session, which means the user will have to implement the rasterio.session.AWSSession themselves, but they can do it very easily using the boto3 session returned from the session property of the client