### PR TITLE
[#31]: absolute and windows path normalization

### DIFF
--- a/docs/examples/upload.ipynb
+++ b/docs/examples/upload.ipynb
@@ -15,7 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from prescient_sdk.upload import upload"
+    "from prescient_sdk.upload import upload\n",
+    "from prescient_sdk.client import PrescientClient\n",
+    "client = PrescientClient(env_file=\"config.env\")"
    ]
   },
   {
@@ -43,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "upload(\"test_upload\")"
+    "upload(\"test_upload\", prescient_client=client)"
    ]
   },
   {
@@ -56,12 +58,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "8a87ab38",
    "metadata": {},
    "outputs": [],
    "source": [
-    "upload(\"test_upload\", exclude=[\"*.txt\", \"*.csv\"])"
+    "upload(\"test_upload\", prescient_client=client, exclude=[\"*.txt\", \"*.csv\"])"
    ]
   },
   {
@@ -74,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "d0412b40",
    "metadata": {},
    "outputs": [
@@ -93,7 +95,7 @@
     "import logging\n",
     "\n",
     "logging.basicConfig(level=logging.INFO)\n",
-    "upload(\"test_upload\", overwrite=False)"
+    "upload(\"test_upload\", prescient_client=client, overwrite=False)"
    ]
   },
   {

--- a/docs/examples/upload.ipynb
+++ b/docs/examples/upload.ipynb
@@ -17,6 +17,7 @@
    "source": [
     "from prescient_sdk.upload import upload\n",
     "from prescient_sdk.client import PrescientClient\n",
+    "\n",
     "client = PrescientClient(env_file=\"config.env\")"
    ]
   },

--- a/docs/examples/upload.ipynb
+++ b/docs/examples/upload.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "d0412b40",
    "metadata": {},
    "outputs": [
@@ -85,9 +85,9 @@
      "output_type": "stream",
      "text": [
       "INFO:prescient_sdk.upload:found 3 files to upload\n",
-      "INFO:prescient_sdk.upload:skipping file test_upload/test.txt as it already exists at s3://upload.enexus.server.prescient.earthtest_upload/test.txt\n",
-      "INFO:prescient_sdk.upload:skipping file test_upload/test.csv as it already exists at s3://upload.enexus.server.prescient.earthtest_upload/test.csv\n",
-      "INFO:prescient_sdk.upload:skipping file test_upload/subdir/test.tif as it already exists at s3://upload.enexus.server.prescient.earthtest_upload/subdir/test.tif\n"
+      "INFO:prescient_sdk.upload:skipping file test_upload/test.txt as it already exists at s3://upload.enexus.server.prescient.earth/test_upload/test.txt\n",
+      "INFO:prescient_sdk.upload:skipping file test_upload/test.csv as it already exists at s3://upload.enexus.server.prescient.earth/test_upload/test.csv\n",
+      "INFO:prescient_sdk.upload:skipping file test_upload/subdir/test.tif as it already exists at s3://upload.enexus.server.prescient.earth/test_upload/subdir/test.tif\n"
      ]
     }
    ],
@@ -97,6 +97,12 @@
     "logging.basicConfig(level=logging.INFO)\n",
     "upload(\"test_upload\", prescient_client=client, overwrite=False)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddba2683",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -56,10 +56,8 @@ def _upload(
 
 def _make_s3_key(file: Path, root: Path) -> str:
     """
-    Compute an S3 key for `file` relative to the `root` directory.
-
-    Ensures the key is normalized with forward slashes (POSIX style),
-    so it works consistently across Windows and POSIX systems.
+    Compute an S3 key for `file` relative to the `root` directory, including
+    the root directory name itself as the top-level folder.
 
     Args:
         file (Path): The full path to the file being uploaded.
@@ -68,7 +66,9 @@ def _make_s3_key(file: Path, root: Path) -> str:
     Returns:
         str: The normalized S3 key.
     """
-    return file.relative_to(root).as_posix()
+    root_name = root.name or root.resolve().name
+    relative_part = file.relative_to(root).as_posix()
+    return f"{root_name}/{relative_part}"
 
 
 def upload(

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -41,7 +41,7 @@ def _upload(
         try:
             _ = s3.head_object(Bucket=bucket, Key=key)
             logger.info(
-                "skipping file %s as it already exists at s3://%s%s", file, bucket, key
+                "skipping file %s as it already exists at s3://%s/%s", file, bucket, key
             )
             return
         except botocore.exceptions.ClientError as e:

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -83,7 +83,11 @@ def upload(
 
     Args:
         input_dir (str | os.PathLike): Input directory containing file(s) to be uploaded.
-            By default will upload all files contained in input directory.
+            By default will upload all files contained in input directory. This can be an
+            absolute or relative path, the final path component will be included as part
+            of the object key e.g. /path/to/data_dir -> s3://bucket/data_dir/file.txt. 
+            When input_dir is a relative path, this should be relative to the current working
+            directory used to execute this function.
         exclude (Optional[list[str]]): A list of glob patterns to exclude from uploading.
             For example `exclude=["*.txt", "*.csv"] would skip any matched files that end with a .txt or
             .csv suffix. If not provided by default all files will be uploaded.

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -85,7 +85,7 @@ def upload(
         input_dir (str | os.PathLike): Input directory containing file(s) to be uploaded.
             By default will upload all files contained in input directory. This can be an
             absolute or relative path, the final path component will be included as part
-            of the object key e.g. /path/to/data_dir -> s3://bucket/data_dir/file.txt. 
+            of the object key e.g. /path/to/data_dir -> s3://bucket/data_dir/file.txt.
             When input_dir is a relative path, this should be relative to the current working
             directory used to execute this function.
         exclude (Optional[list[str]]): A list of glob patterns to exclude from uploading.

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -86,10 +86,13 @@ def upload(
     files = list(iter_files(input_path, exclude=exclude))
     logger.info("found %s files to upload", len(files))
     for file in files:
+        # Get key relative to path
+        relative_key = file.relative_to(input_path).as_posix() # as_posix handles windows paths
+
         _upload(
             file=str(file),
             bucket=prescient_client.settings.prescient_upload_bucket,
-            key=file.as_posix(),
+            key=relative_key,
             session=prescient_client.upload_session,
             overwrite=overwrite,
         )

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -50,7 +50,7 @@ def _upload(
             else:
                 raise e
 
-    logger.info("uploading file %s to s3://%s%s", file, bucket, key)
+    logger.info("uploading file %s to s3://%s/%s", file, bucket, key)
     s3.upload_file(Filename=file, Bucket=bucket, Key=key)
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -67,6 +67,7 @@ def test_upload(
     assert "Contents" in results
     assert len(results["Contents"]) == 1
     assert results["Contents"][0]["Key"].endswith("test.txt")
+    assert test_path.parent.name in results["Contents"][0]["Key"]
     for record in caplog.records:
         assert "uploading file" in record.message
     caplog.clear()
@@ -122,6 +123,11 @@ def test_make_s3_key_windows_style():
 
     assert file.relative_to(root).as_posix() == "nested/file.txt"
 
+def test_make_s3_key_relative_root(tmp_path):
+    root = Path("../data")
+    file = root / "a.txt"
+
+    assert _make_s3_key(file, root) == "data/a.txt"
 
 def test_upload_invalid_dir(tmp_path):
     tmp_dir = tmp_path.joinpath("some-dir")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -123,58 +123,6 @@ def test_make_s3_key_windows_style():
     assert file.relative_to(root).as_posix() == "nested/file.txt"
 
 
-# @mock_aws
-# @pytest.mark.parametrize("style", ["relative", "absolute", "posix"])
-# def test_upload_key_normalization_real_paths(
-#     tmp_path,
-#     set_env_vars,
-#     mock_creds,
-#     unexpired_auth_credentials_mock,
-#     create_test_bucket,
-#     aws_credentials,
-#     s3,
-#     style,
-# ):
-#     client = PrescientClient()
-#     client._auth_credentials = unexpired_auth_credentials_mock
-#     client.settings.prescient_aws_region = "us-east-1"
-#
-#     subdir = tmp_path / "nested"
-#     subdir.mkdir()
-#     test_file = subdir / "test.txt"
-#     test_file.write_text("hello")
-#
-#     if style == "relative":
-#         input_dir = str(tmp_path.relative_to(Path.cwd()))
-#     elif style == "absolute":
-#         input_dir = str(tmp_path.resolve())
-#     elif style == "posix":
-#         input_dir = tmp_path.as_posix()
-#
-#     upload(input_dir, prescient_client=client)
-#
-#     results = s3.list_objects_v2(Bucket="test-bucket")
-#     keys = [obj["Key"] for obj in results.get("Contents", [])]
-#
-#     assert "nested/test.txt" in keys
-#     assert not any("tmp" in key or ":" in key for key in keys)
-#
-#
-# def test_relative_key_normalization_windows_style(tmp_path):
-#     input_dir = tmp_path.resolve()
-#     file_path = input_dir / "nested" / "test.txt"
-#     file_path.parent.mkdir()
-#     file_path.touch()
-#
-#     # Simulate Windows-style absolute paths
-#     win_file = PureWindowsPath("C:/data/project/nested/test.txt")
-#     win_input = PureWindowsPath("C:/data/project")
-#
-#     rel_key = win_file.relative_to(win_input).as_posix()
-#
-#     assert rel_key == "nested/test.txt"
-
-
 def test_upload_invalid_dir(tmp_path):
     tmp_dir = tmp_path.joinpath("some-dir")
     with pytest.raises(FileNotFoundError):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,9 +1,8 @@
-import time
-import pytest
-from moto import mock_aws
-
 from prescient_sdk.client import PrescientClient
 from prescient_sdk.upload import iter_files, upload
+from moto import mock_aws
+import time
+import pytest
 
 
 @pytest.fixture

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,4 @@
 import time
-from pathlib import Path, PureWindowsPath
-import platform
 import pytest
 from moto import mock_aws
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,5 @@
 import time
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import platform
 import pytest
 from moto import mock_aws
@@ -122,7 +122,7 @@ def test_upload_key_normalization_real_paths(
     test_file.write_text("hello")
 
     if style == "relative":
-        input_dir = str(tmp_path.relative_to(tmp_path.parent))
+        input_dir = str(tmp_path.relative_to(Path.cwd()))
     elif style == "absolute":
         input_dir = str(tmp_path.resolve())
     elif style == "posix":
@@ -141,10 +141,13 @@ def test_relative_key_normalization_windows_style(tmp_path):
     input_dir = tmp_path.resolve()
     file_path = input_dir / "nested" / "test.txt"
     file_path.parent.mkdir()
-    file_path.write_text("test")
-    win_file_str = str(file_path).replace("/", "\\")
-    win_input_str = str(input_dir).replace("/", "\\")
-    rel_key = Path(win_file_str).relative_to(Path(win_input_str)).as_posix()
+    file_path.touch()
+
+    # Simulate Windows-style absolute paths
+    win_file = PureWindowsPath("C:/data/project/nested/test.txt")
+    win_input = PureWindowsPath("C:/data/project")
+
+    rel_key = win_file.relative_to(win_input).as_posix()
 
     assert rel_key == "nested/test.txt"
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -101,8 +101,8 @@ def test_upload(
 
 
 @mock_aws
-@pytest.mark.parametrize("style", ["relative", "absolute", "posix", "windows"])
-def test_upload_key_normalization(
+@pytest.mark.parametrize("style", ["relative", "absolute", "posix"])
+def test_upload_key_normalization_real_paths(
     tmp_path,
     set_env_vars,
     mock_creds,
@@ -116,7 +116,6 @@ def test_upload_key_normalization(
     client._auth_credentials = unexpired_auth_credentials_mock
     client.settings.prescient_aws_region = "us-east-1"
 
-    # make a subdirectory and a file
     subdir = tmp_path / "nested"
     subdir.mkdir()
     test_file = subdir / "test.txt"
@@ -128,11 +127,6 @@ def test_upload_key_normalization(
         input_dir = str(tmp_path.resolve())
     elif style == "posix":
         input_dir = tmp_path.as_posix()
-    elif style == "windows":
-        drive = "C:" if platform.system() != "Windows" else Path(tmp_path).drive
-        input_dir = f"{drive}\\{tmp_path.relative_to(tmp_path.anchor)}"
-    else:
-        raise ValueError(style)
 
     upload(input_dir, prescient_client=client)
 
@@ -141,6 +135,23 @@ def test_upload_key_normalization(
 
     assert "nested/test.txt" in keys
     assert not any("tmp" in key or ":" in key for key in keys)
+
+
+def test_relative_key_normalization_windows_style(tmp_path):
+    # simulate a Windows-style absolute path
+    input_dir = tmp_path.resolve()
+    file_path = input_dir / "nested" / "test.txt"
+    file_path.parent.mkdir()
+    file_path.write_text("test")
+
+    # Pretend we are on Windows by forcing backslashes into the string
+    win_file_str = str(file_path).replace("/", "\\")
+    win_input_str = str(input_dir).replace("/", "\\")
+
+    # When computing relative key
+    rel_key = Path(win_file_str).relative_to(Path(win_input_str)).as_posix()
+
+    assert rel_key == "nested/test.txt"
 
 
 def test_upload_invalid_dir(tmp_path):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -105,7 +105,8 @@ def test_make_s3_key_posix_absolute(tmp_path):
     file.parent.mkdir()
     file.touch()
 
-    assert _make_s3_key(file, root) == "a/b.txt"
+    expected = f"{root.name}/a/b.txt"
+    assert _make_s3_key(file, root) == expected
 
 
 def test_make_s3_key_posix_relative(tmp_path):
@@ -113,8 +114,8 @@ def test_make_s3_key_posix_relative(tmp_path):
     file = tmp_path / "c.txt"
     file.touch()
 
-    # root and file are the same tmp_path base
-    assert _make_s3_key(file, root) == "c.txt"
+    expected = f"{root.name}/c.txt"
+    assert _make_s3_key(file, root) == expected
 
 
 def test_make_s3_key_windows_style():
@@ -123,11 +124,13 @@ def test_make_s3_key_windows_style():
 
     assert file.relative_to(root).as_posix() == "nested/file.txt"
 
+
 def test_make_s3_key_relative_root(tmp_path):
     root = Path("../data")
     file = root / "a.txt"
 
     assert _make_s3_key(file, root) == "data/a.txt"
+
 
 def test_upload_invalid_dir(tmp_path):
     tmp_dir = tmp_path.joinpath("some-dir")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,7 @@
 from prescient_sdk.client import PrescientClient
-from prescient_sdk.upload import iter_files, upload
+from prescient_sdk.upload import iter_files, upload, _make_s3_key
 from moto import mock_aws
+from pathlib import Path, PureWindowsPath
 import time
 import pytest
 
@@ -95,10 +96,6 @@ def test_upload(
     for record in caplog.records:
         assert "skipping file" in record.message
     caplog.clear()
-
-
-from pathlib import Path, PureWindowsPath
-from prescient_sdk.upload import _make_s3_key
 
 
 def test_make_s3_key_posix_absolute(tmp_path):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -138,17 +138,12 @@ def test_upload_key_normalization_real_paths(
 
 
 def test_relative_key_normalization_windows_style(tmp_path):
-    # simulate a Windows-style absolute path
     input_dir = tmp_path.resolve()
     file_path = input_dir / "nested" / "test.txt"
     file_path.parent.mkdir()
     file_path.write_text("test")
-
-    # Pretend we are on Windows by forcing backslashes into the string
     win_file_str = str(file_path).replace("/", "\\")
     win_input_str = str(input_dir).replace("/", "\\")
-
-    # When computing relative key
     rel_key = Path(win_file_str).relative_to(Path(win_input_str)).as_posix()
 
     assert rel_key == "nested/test.txt"


### PR DESCRIPTION
This PR fixes bugs #31 and #33 to normalize relative and absolute (and windows) path behaviour for s3 uploads and logging. 