### PR TITLE
Phase 3: Settings — env var loading and validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ permissions: {}  # deny all; jobs declare only what they need
 jobs:
   run-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 
@@ -47,3 +48,34 @@ jobs:
     - name: check-format
       run: |
         uv run ruff check
+
+  typescript-sdk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: prescient-sdk-ts
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      with:
+        version: "11.1.2"
+
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      with:
+        node-version: "22"
+        cache: "pnpm"
+        cache-dependency-path: prescient-sdk-ts/pnpm-lock.yaml
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Build
+      run: pnpm run build
+
+    - name: Test
+      run: pnpm test

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+title = "prescient-sdk gitleaks configuration"
+
+[allowlist]
+  description = "Test fixture allowlist — placeholder values that look like secrets"
+  paths = [
+    '''prescient-sdk-ts/src/__tests__''',
+  ]
+  regexes = [
+    '''AKIAPLACEHOLDER''',
+    '''FAKE_SECRET_NOT_REAL_DO_NOT_USE''',
+    '''FAKE_SESSION_TOKEN_PLACEHOLDER''',
+    '''PLACEHOLDER_TOKEN''',
+  ]

--- a/prescient-sdk-ts/.npmignore
+++ b/prescient-sdk-ts/.npmignore
@@ -1,0 +1,16 @@
+
+# Exclude typescript source and config
+*.ts
+tsconfig.json
+*.tsbuildinfo
+
+# Include javascript files and typescript declarations
+!*.js
+!*.d.ts
+
+# Exclude jsii outdir
+targets
+
+# Include .jsii and .jsii.gz
+!.jsii
+!.jsii.gz

--- a/prescient-sdk-ts/src/__tests__/settings.test.ts
+++ b/prescient-sdk-ts/src/__tests__/settings.test.ts
@@ -13,7 +13,7 @@ const GOOGLE_ENV = {
   PRESCIENT_CLIENT_ID: 'client-id',
   PRESCIENT_AUTH_URL: 'https://auth.example.com',
   PRESCIENT_AUTH_PROVIDER: 'google',
-  PRESCIENT_GOOGLE_CLIENT_SECRET: 'google-secret',
+  PRESCIENT_GOOGLE_CLIENT_SECRET: 'google-secret', // gitleaks:allow
 };
 
 function withEnv(vars: Record<string, string>, fn: () => void): void {
@@ -150,6 +150,88 @@ describe('Settings — validation errors', () => {
     withEnv({ ...GOOGLE_ENV, PRESCIENT_GOOGLE_REDIRECT_PORT: '99999' }, () => {
       expect(() => new Settings()).toThrow('Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "99999"');
     });
+  });
+});
+
+describe('Settings — port boundary validation', () => {
+  it('throws on out-of-range googleRedirectPort option (0)', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => { // gitleaks:allow
+      expect(() =>
+        new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE, googleRedirectPort: 0 }),
+      ).toThrow('googleRedirectPort must be an integer 1–65535');
+    });
+  });
+
+  it('throws on out-of-range googleRedirectPort option (65536)', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => { // gitleaks:allow
+      expect(() =>
+        new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE, googleRedirectPort: 65536 }),
+      ).toThrow('googleRedirectPort must be an integer 1–65535');
+    });
+  });
+
+  it('throws on non-integer googleRedirectPort option (1.5)', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => { // gitleaks:allow
+      expect(() =>
+        new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE, googleRedirectPort: 1.5 }),
+      ).toThrow('googleRedirectPort must be an integer 1–65535');
+    });
+  });
+
+  it('throws on scientific-notation PRESCIENT_GOOGLE_REDIRECT_PORT', () => {
+    withEnv({ ...GOOGLE_ENV, PRESCIENT_GOOGLE_REDIRECT_PORT: '1e4' }, () => {
+      expect(() => new Settings()).toThrow('Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "1e4"');
+    });
+  });
+});
+
+describe('Settings — SSRF prevention', () => {
+  it('throws if endpointUrl targets IMDS (169.254.169.254)', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, endpointUrl: 'https://169.254.169.254/latest' }),
+    ).toThrow('must not target internal infrastructure');
+  });
+
+  it('throws if endpointUrl targets localhost', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, endpointUrl: 'https://localhost:8080' }),
+    ).toThrow('must not target internal infrastructure');
+  });
+
+  it('throws if endpointUrl targets RFC 1918 (192.168.x.x)', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, endpointUrl: 'https://192.168.1.1' }),
+    ).toThrow('must not target internal infrastructure');
+  });
+
+  it('throws if authUrl targets RFC 1918 (10.x.x.x)', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, authUrl: 'https://10.0.0.1/token' }),
+    ).toThrow('must not target internal infrastructure');
+  });
+});
+
+describe('Settings — toJSON', () => {
+  it('excludes _googleClientSecret from JSON.stringify', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => { // gitleaks:allow
+      const s = new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE });
+      const json = JSON.parse(JSON.stringify(s)) as Record<string, unknown>;
+      expect(json['_googleClientSecret']).toBeUndefined();
+      expect(json['endpointUrl']).toBe('https://api.example.com');
+    });
+  });
+});
+
+describe('Settings — awsRole validation', () => {
+  it('accepts a valid ARN', () => {
+    const s = new Settings({ ...MICROSOFT_OPTS, awsRole: 'arn:aws:iam::123456789012:role/MyRole' });
+    expect(s.awsRole).toBe('arn:aws:iam::123456789012:role/MyRole');
+  });
+
+  it('throws on invalid awsRole (missing arn: prefix)', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, awsRole: 'not-an-arn' }),
+    ).toThrow('awsRole must be a valid AWS ARN');
   });
 });
 

--- a/prescient-sdk-ts/src/__tests__/settings.test.ts
+++ b/prescient-sdk-ts/src/__tests__/settings.test.ts
@@ -1,0 +1,166 @@
+import { Settings } from '../settings';
+import { AuthProvider } from '../types';
+
+const BASE = {
+  endpointUrl: 'https://api.example.com',
+  clientId: 'client-id',
+  authUrl: 'https://auth.example.com',
+};
+
+const MICROSOFT_OPTS = { ...BASE, tenantId: 'tenant-id' };
+const GOOGLE_ENV = {
+  PRESCIENT_ENDPOINT_URL: 'https://api.example.com',
+  PRESCIENT_CLIENT_ID: 'client-id',
+  PRESCIENT_AUTH_URL: 'https://auth.example.com',
+  PRESCIENT_AUTH_PROVIDER: 'google',
+  PRESCIENT_GOOGLE_CLIENT_SECRET: 'google-secret',
+};
+
+function withEnv(vars: Record<string, string>, fn: () => void): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of Object.keys(vars)) {
+    saved[k] = process.env[k];
+    process.env[k] = vars[k];
+  }
+  try {
+    fn();
+  } finally {
+    for (const k of Object.keys(vars)) {
+      if (saved[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = saved[k];
+      }
+    }
+  }
+}
+
+describe('Settings — from options', () => {
+  it('constructs with microsoft provider and tenantId', () => {
+    const s = new Settings(MICROSOFT_OPTS);
+    expect(s.endpointUrl).toBe('https://api.example.com');
+    expect(s.authProvider).toBe(AuthProvider.MICROSOFT);
+    expect(s.tenantId).toBe('tenant-id');
+    expect(s.googleRedirectPort).toBe(8765);
+  });
+
+  it('constructs with google provider (secret from env)', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => {
+      const s = new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE });
+      expect(s.authProvider).toBe(AuthProvider.GOOGLE);
+      expect(s._googleClientSecret).toBe('secret');
+    });
+  });
+
+  it('defaults authProvider to MICROSOFT', () => {
+    const s = new Settings(MICROSOFT_OPTS);
+    expect(s.authProvider).toBe(AuthProvider.MICROSOFT);
+  });
+
+  it('uses provided googleRedirectPort', () => {
+    withEnv({ PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret' }, () => {
+      const s = new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE, googleRedirectPort: 9000 });
+      expect(s.googleRedirectPort).toBe(9000);
+    });
+  });
+});
+
+describe('Settings — from environment variables', () => {
+  it('reads all PRESCIENT_* env vars', () => {
+    withEnv(GOOGLE_ENV, () => {
+      const s = new Settings();
+      expect(s.endpointUrl).toBe('https://api.example.com');
+      expect(s.authProvider).toBe(AuthProvider.GOOGLE);
+      expect(s._googleClientSecret).toBe('google-secret');
+    });
+  });
+
+  it('env var overrides default redirect port', () => {
+    withEnv({ ...GOOGLE_ENV, PRESCIENT_GOOGLE_REDIRECT_PORT: '4321' }, () => {
+      const s = new Settings();
+      expect(s.googleRedirectPort).toBe(4321);
+    });
+  });
+
+  it('parses PRESCIENT_AUTH_PROVIDER case-insensitively', () => {
+    withEnv({ ...GOOGLE_ENV, PRESCIENT_AUTH_PROVIDER: 'GOOGLE' }, () => {
+      const s = new Settings();
+      expect(s.authProvider).toBe(AuthProvider.GOOGLE);
+    });
+  });
+});
+
+describe('Settings — validation errors', () => {
+  it('throws if endpointUrl missing', () => {
+    expect(() => new Settings({ ...BASE, endpointUrl: '' } as any)).toThrow(
+      'endpointUrl is required',
+    );
+  });
+
+  it('throws if endpointUrl is http://', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, endpointUrl: 'http://api.example.com' }),
+    ).toThrow('endpointUrl must be an HTTPS URL');
+  });
+
+  it('throws if authUrl is http://', () => {
+    expect(() =>
+      new Settings({ ...MICROSOFT_OPTS, authUrl: 'http://auth.example.com' }),
+    ).toThrow('authUrl must be an HTTPS URL');
+  });
+
+  it('throws if clientId missing', () => {
+    expect(() => new Settings({ ...BASE, clientId: '', tenantId: 'tid' })).toThrow(
+      'clientId is required',
+    );
+  });
+
+  it('throws if microsoft provider missing tenantId', () => {
+    expect(() => new Settings({ ...BASE, authProvider: AuthProvider.MICROSOFT })).toThrow(
+      'tenantId is required when authProvider is MICROSOFT',
+    );
+  });
+
+  it('throws if google provider missing PRESCIENT_GOOGLE_CLIENT_SECRET', () => {
+    expect(() =>
+      new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE }),
+    ).toThrow('PRESCIENT_GOOGLE_CLIENT_SECRET env var is required');
+  });
+
+  it('throws on invalid PRESCIENT_AUTH_PROVIDER env value', () => {
+    withEnv(
+      {
+        ...GOOGLE_ENV,
+        PRESCIENT_AUTH_PROVIDER: 'facebook',
+        PRESCIENT_GOOGLE_CLIENT_SECRET: 'secret',
+      },
+      () => {
+        expect(() => new Settings()).toThrow('Invalid PRESCIENT_AUTH_PROVIDER value "facebook"');
+      },
+    );
+  });
+
+  it('throws on invalid PRESCIENT_GOOGLE_REDIRECT_PORT', () => {
+    withEnv({ ...GOOGLE_ENV, PRESCIENT_GOOGLE_REDIRECT_PORT: 'abc' }, () => {
+      expect(() => new Settings()).toThrow('Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "abc"');
+    });
+  });
+
+  it('throws on out-of-range PRESCIENT_GOOGLE_REDIRECT_PORT', () => {
+    withEnv({ ...GOOGLE_ENV, PRESCIENT_GOOGLE_REDIRECT_PORT: '99999' }, () => {
+      expect(() => new Settings()).toThrow('Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "99999"');
+    });
+  });
+});
+
+describe('Settings — opts take precedence over env', () => {
+  it('opts.endpointUrl wins over PRESCIENT_ENDPOINT_URL', () => {
+    withEnv(
+      { ...GOOGLE_ENV, PRESCIENT_ENDPOINT_URL: 'https://env.example.com' },
+      () => {
+        const s = new Settings({ ...BASE, authProvider: AuthProvider.GOOGLE });
+        expect(s.endpointUrl).toBe('https://api.example.com');
+      },
+    );
+  });
+});

--- a/prescient-sdk-ts/src/index.ts
+++ b/prescient-sdk-ts/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './settings';

--- a/prescient-sdk-ts/src/settings.ts
+++ b/prescient-sdk-ts/src/settings.ts
@@ -1,0 +1,133 @@
+import { AuthProvider, PrescientClientOptions } from './types';
+
+/**
+ * Resolved, validated settings for PrescientClient.
+ *
+ * Constructed either from a {@link PrescientClientOptions} struct or from
+ * `PRESCIENT_*` environment variables (falling back to a `config.env` file
+ * if `dotenv` is loaded by the consumer). Validation enforces HTTPS on all
+ * URL fields and requires provider-specific fields.
+ *
+ * Environment variable → field mapping:
+ * ```
+ * PRESCIENT_ENDPOINT_URL          → endpointUrl
+ * PRESCIENT_AUTH_PROVIDER         → authProvider
+ * PRESCIENT_CLIENT_ID             → clientId
+ * PRESCIENT_AUTH_URL              → authUrl
+ * PRESCIENT_TENANT_ID             → tenantId
+ * PRESCIENT_GOOGLE_CLIENT_SECRET  → _googleClientSecret  (never in Options struct)
+ * PRESCIENT_GOOGLE_REDIRECT_PORT  → googleRedirectPort
+ * PRESCIENT_AWS_ROLE              → awsRole
+ * PRESCIENT_AWS_REGION            → awsRegion
+ * PRESCIENT_UPLOAD_ROLE           → uploadRole
+ * PRESCIENT_UPLOAD_BUCKET         → uploadBucket
+ * ```
+ */
+export class Settings {
+  readonly endpointUrl: string;
+  readonly authProvider: AuthProvider;
+  readonly clientId: string;
+  readonly authUrl: string;
+  readonly tenantId?: string;
+  /** @internal Never exposed in PrescientClientOptions — read from env only. */
+  readonly _googleClientSecret?: string;
+  readonly googleRedirectPort: number;
+  readonly awsRole?: string;
+  readonly awsRegion?: string;
+  readonly uploadRole?: string;
+  readonly uploadBucket?: string;
+
+  constructor(opts?: PrescientClientOptions) {
+    const env = process.env;
+
+    this.endpointUrl = opts?.endpointUrl ?? env['PRESCIENT_ENDPOINT_URL'] ?? '';
+    this.authProvider = resolveAuthProvider(
+      opts?.authProvider,
+      env['PRESCIENT_AUTH_PROVIDER'],
+    );
+    this.clientId = opts?.clientId ?? env['PRESCIENT_CLIENT_ID'] ?? '';
+    this.authUrl = opts?.authUrl ?? env['PRESCIENT_AUTH_URL'] ?? '';
+    this.tenantId = opts?.tenantId ?? env['PRESCIENT_TENANT_ID'];
+    this._googleClientSecret = env['PRESCIENT_GOOGLE_CLIENT_SECRET'];
+    this.googleRedirectPort = resolvePort(
+      opts?.googleRedirectPort,
+      env['PRESCIENT_GOOGLE_REDIRECT_PORT'],
+    );
+    this.awsRole = opts?.awsRole ?? env['PRESCIENT_AWS_ROLE'];
+    this.awsRegion = opts?.awsRegion ?? env['PRESCIENT_AWS_REGION'];
+    this.uploadRole = opts?.uploadRole ?? env['PRESCIENT_UPLOAD_ROLE'];
+    this.uploadBucket = opts?.uploadBucket ?? env['PRESCIENT_UPLOAD_BUCKET'];
+
+    this.validate();
+  }
+
+  private validate(): void {
+    if (!this.endpointUrl) {
+      throw new Error(
+        'endpointUrl is required. Set PRESCIENT_ENDPOINT_URL or pass endpointUrl in options.',
+      );
+    }
+    assertHttps(this.endpointUrl, 'endpointUrl');
+
+    if (!this.clientId) {
+      throw new Error(
+        'clientId is required. Set PRESCIENT_CLIENT_ID or pass clientId in options.',
+      );
+    }
+
+    if (!this.authUrl) {
+      throw new Error(
+        'authUrl is required. Set PRESCIENT_AUTH_URL or pass authUrl in options.',
+      );
+    }
+    assertHttps(this.authUrl, 'authUrl');
+
+    if (this.authProvider === AuthProvider.MICROSOFT && !this.tenantId) {
+      throw new Error(
+        'tenantId is required when authProvider is MICROSOFT. ' +
+          'Set PRESCIENT_TENANT_ID or pass tenantId in options.',
+      );
+    }
+
+    if (this.authProvider === AuthProvider.GOOGLE && !this._googleClientSecret) {
+      throw new Error(
+        'PRESCIENT_GOOGLE_CLIENT_SECRET env var is required when authProvider is GOOGLE.',
+      );
+    }
+  }
+}
+
+function resolveAuthProvider(
+  fromOpts: AuthProvider | undefined,
+  fromEnv: string | undefined,
+): AuthProvider {
+  if (fromOpts !== undefined) return fromOpts;
+  if (fromEnv === undefined) return AuthProvider.MICROSOFT;
+  const lower = fromEnv.toLowerCase();
+  if (lower === 'google') return AuthProvider.GOOGLE;
+  if (lower === 'microsoft') return AuthProvider.MICROSOFT;
+  throw new Error(
+    `Invalid PRESCIENT_AUTH_PROVIDER value "${fromEnv}". Must be "microsoft" or "google".`,
+  );
+}
+
+function resolvePort(fromOpts: number | undefined, fromEnv: string | undefined): number {
+  if (fromOpts !== undefined) return fromOpts;
+  if (fromEnv === undefined) return 8765;
+  const n = Number(fromEnv);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(
+      `Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "${fromEnv}". Must be an integer 1–65535.`,
+    );
+  }
+  return n;
+}
+
+function assertHttps(url: string, field: string): void {
+  if (!url.startsWith('https://')) {
+    throw new Error(
+      `${field} must be an HTTPS URL. Received: "${url}". ` +
+        'HTTP is not supported — credentials would be transmitted in plaintext.',
+    );
+  }
+}

--- a/prescient-sdk-ts/src/settings.ts
+++ b/prescient-sdk-ts/src/settings.ts
@@ -68,6 +68,7 @@ export class Settings {
       );
     }
     assertHttps(this.endpointUrl, 'endpointUrl');
+    assertNotSsrf(this.endpointUrl, 'endpointUrl');
 
     if (!this.clientId) {
       throw new Error(
@@ -81,6 +82,7 @@ export class Settings {
       );
     }
     assertHttps(this.authUrl, 'authUrl');
+    assertNotSsrf(this.authUrl, 'authUrl');
 
     if (this.authProvider === AuthProvider.MICROSOFT && !this.tenantId) {
       throw new Error(
@@ -94,6 +96,34 @@ export class Settings {
         'PRESCIENT_GOOGLE_CLIENT_SECRET env var is required when authProvider is GOOGLE.',
       );
     }
+
+    if (this.awsRole !== undefined) {
+      if (!this.awsRole.startsWith('arn:') || this.awsRole.length > 2048) {
+        throw new Error(
+          `awsRole must be a valid AWS ARN (e.g. arn:aws:iam::123456789012:role/MyRole). ` +
+            `Received: "${this.awsRole}".`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Returns a JSON-safe representation that excludes `_googleClientSecret`.
+   * Called automatically by `JSON.stringify()`.
+   */
+  toJSON(): PrescientClientOptions {
+    return {
+      endpointUrl: this.endpointUrl,
+      authProvider: this.authProvider,
+      clientId: this.clientId,
+      authUrl: this.authUrl,
+      tenantId: this.tenantId,
+      googleRedirectPort: this.googleRedirectPort,
+      awsRole: this.awsRole,
+      awsRegion: this.awsRegion,
+      uploadRole: this.uploadRole,
+      uploadBucket: this.uploadBucket,
+    };
   }
 }
 
@@ -112,10 +142,15 @@ function resolveAuthProvider(
 }
 
 function resolvePort(fromOpts: number | undefined, fromEnv: string | undefined): number {
-  if (fromOpts !== undefined) return fromOpts;
+  if (fromOpts !== undefined) {
+    if (!Number.isInteger(fromOpts) || fromOpts < 1 || fromOpts > 65535) {
+      throw new Error(`googleRedirectPort must be an integer 1–65535. Received: ${fromOpts}.`);
+    }
+    return fromOpts;
+  }
   if (fromEnv === undefined) return 8765;
-  const n = Number(fromEnv);
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+  const n = parseInt(fromEnv, 10);
+  if (isNaN(n) || n < 1 || n > 65535 || String(n) !== fromEnv.trim()) {
     throw new Error(
       `Invalid PRESCIENT_GOOGLE_REDIRECT_PORT value "${fromEnv}". Must be an integer 1–65535.`,
     );
@@ -125,9 +160,46 @@ function resolvePort(fromOpts: number | undefined, fromEnv: string | undefined):
 
 function assertHttps(url: string, field: string): void {
   if (!url.startsWith('https://')) {
+    let display: string;
+    try {
+      display = new URL(url).origin;
+    } catch {
+      display = '<invalid URL>';
+    }
     throw new Error(
-      `${field} must be an HTTPS URL. Received: "${url}". ` +
+      `${field} must be an HTTPS URL. Received: "${display}". ` +
         'HTTP is not supported — credentials would be transmitted in plaintext.',
     );
+  }
+}
+
+const SSRF_BLOCKED_HOSTS = new Set(['localhost', '0.0.0.0', '[::1]', '169.254.169.254']);
+
+function assertNotSsrf(url: string, field: string): void {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    throw new Error(`${field} is not a valid URL.`);
+  }
+  if (SSRF_BLOCKED_HOSTS.has(host)) {
+    throw new Error(
+      `${field} must not target internal infrastructure. "${host}" is not allowed.`,
+    );
+  }
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4) {
+    const a = parseInt(ipv4[1], 10);
+    const b = parseInt(ipv4[2], 10);
+    if (
+      a === 10 ||
+      a === 127 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168)
+    ) {
+      throw new Error(
+        `${field} must not target internal infrastructure. "${host}" is a private/loopback address.`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `Settings` class reads all `PRESCIENT_*` env vars with `PrescientClientOptions` taking precedence
- **HTTPS enforced** on `endpointUrl` and `authUrl` at construction — throws descriptive error for `http://` (Phase 2 blocker resolved)
- Required-field validation: `endpointUrl`, `clientId`, `authUrl` always required; `tenantId` required for Microsoft; `PRESCIENT_GOOGLE_CLIENT_SECRET` env var required for Google
- `_googleClientSecret` stored as `@internal` `_`-prefixed field — stripped from jsii assembly, never appears in Python/Go/C#/Java bindings, never crosses IPC boundary
- `googleRedirectPort` defaults to `8765`; validates env var as integer 1–65535
- `PRESCIENT_AUTH_PROVIDER` parsed case-insensitively

## Test plan

- [ ] `pnpm run build` — `Errors: 0 | Warnings: 0`
- [ ] `pnpm test` — 26 tests pass (17 settings + 9 types)
- [ ] Confirm `_googleClientSecret` not present in `.jsii` assembly types
- [ ] Confirm `http://` endpoint URL throws at construction, not silently accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)