### PR TITLE
fix: add future annotations for type hint compatibility

### DIFF
--- a/prescient_sdk/client.py
+++ b/prescient_sdk/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 import urllib.parse

--- a/prescient_sdk/config.py
+++ b/prescient_sdk/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Literal
 


### PR DESCRIPTION
## Summary

Add from __future__ import annotations to modules that use modern type annotations.

## Motivation

QGIS LTR currently ships with Python 3.9. Importing modules containing annotations such as:

str | None

causes Python 3.9 to evaluate the union expression at import time, resulting in:

TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

Using postponed evaluation of annotations prevents type hints from being evaluated during import and allows the modules to be imported successfully under Python 3.9.

## Changes
Add from __future__ import annotations to the affected modules.
No functional changes to runtime behavior.
Preserves compatibility with Python 3.10+ while improving compatibility with Python 3.9 environments such as QGIS LTR.