### PR TITLE
55 ingest resource testing

### DIFF
--- a/docs/examples/ingest.ipynb
+++ b/docs/examples/ingest.ipynb
@@ -1,6 +1,6 @@
-{
+{IngesIngestResource
  "cells": [
-  {
+  {IngestResource
    "cell_type": "markdown",
    "id": "a1000001",
    "metadata": {},

--- a/docs/examples/ingest.ipynb
+++ b/docs/examples/ingest.ipynb
@@ -1,10 +1,21 @@
-{IngesIngestResource
+{
  "cells": [
-  {IngestResource
+  {
    "cell_type": "markdown",
    "id": "a1000001",
    "metadata": {},
-   "source": "# Ingestion\n\nThe `IngestClient` wraps the Prescient Ingest API and returns typed pydantic models. The workflow follows two phases:\n\n1. **Create** an ingestion from a YAML specification, then poll until it is `READY`.\n2. **Start** the ingestion, then poll until it is `DONE` (or `FAILED` / `INCOMPLETE`).\n\nAfter the first ingestion completes, new data can be picked up by creating additional **batches** that follow the same specification.\n\nAuthentication is delegated to a `PrescientClient`, so the same `config.env` used elsewhere in the SDK works here. By default the Ingest API base URL is `<prescient_endpoint_url>/ingest/`; set `PRESCIENT_INGEST_ENDPOINT_URL` to override that (e.g. when the Ingest API is deployed at a separate host)."
+   "source": [
+    "# Ingestion\n",
+    "\n",
+    "The `IngestClient` wraps the Prescient Ingest API and returns typed pydantic models. The workflow follows two phases:\n",
+    "\n",
+    "1. **Create** an ingestion from a YAML specification, then poll until it is `READY`.\n",
+    "2. **Start** the ingestion, then poll until it is `DONE` (or `FAILED` / `INCOMPLETE`).\n",
+    "\n",
+    "After the first ingestion completes, new data can be picked up by creating additional **batches** that follow the same specification.\n",
+    "\n",
+    "Authentication is delegated to a `PrescientClient`, so the same `config.env` used elsewhere in the SDK works here. By default the Ingest API base URL is `<prescient_endpoint_url>/ingest/`; set `PRESCIENT_INGEST_ENDPOINT_URL` to override that (e.g. when the Ingest API is deployed at a separate host)."
+   ]
   },
   {
    "cell_type": "code",
@@ -12,7 +23,17 @@
    "id": "a1000002",
    "metadata": {},
    "outputs": [],
-   "source": "from pathlib import Path\n\nfrom prescient_sdk.ingest_client import IngestClient\nfrom prescient_sdk.ingest_models import ErrorSeverity, Status\n\nclient = IngestClient(env_file=\"config.env\")\n\n# Quick liveness check against the Ingest API.\nclient.check()"
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from prescient_sdk.ingest_client import IngestClient\n",
+    "from prescient_sdk.ingest_models import ErrorSeverity, Status\n",
+    "\n",
+    "client = IngestClient(env_file=\"config.env\")\n",
+    "\n",
+    "# Quick liveness check against the Ingest API.\n",
+    "client.check()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -211,44 +232,78 @@
   {
    "cell_type": "markdown",
    "id": "9e3f0af2",
-   "source": "## Higher-level workflow: the `IngestionResource` class\n\n`IngestClient` is a faithful 1:1 wrapper around the REST API — useful if you want full control, but verbose for everyday work. For most use cases the SDK ships an `IngestionResource` class that wraps the client and lets you compose multi-step workflows from named methods.\n\nConstruct it with `IngestionResource.create(...)` (POST a new ingestion) or `IngestionResource.from_id(...)` (attach to an existing one). To get a live, auto-updating Rich progress display during long polls, wrap the resource in `LiveStatus`: the display animates as the ingestion moves through `SCANNING` → `READY` → `INGESTING` → `DONE`, and a final summary is rendered when the `with` block exits.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Higher-level workflow: the `IngestResource` class\n",
+    "\n",
+    "`IngestClient` is a faithful 1:1 wrapper around the REST API — useful if you want full control, but verbose for everyday work. For most use cases the SDK ships an `IngestResource` class that wraps the client and lets you compose multi-step workflows from named methods.\n",
+    "\n",
+    "Construct it with `IngestResource.create(...)` (POST a new ingestion) or `IngestResource.from_id(...)` (attach to an existing one). To get a live, auto-updating Rich progress display during long polls, wrap the resource in `LiveStatus`: the display animates as the ingestion moves through `SCANNING` → `READY` → `INGESTING` → `DONE`, and a final summary is rendered when the `with` block exits."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "a1b08239",
-   "source": "from prescient_sdk import IngestionResource, LiveStatus\n\ning = IngestionResource.create(client, spec=Path(\"spec.yaml\"))\nwith LiveStatus(ing):\n    ing.wait_until_ready()\n    if not any(e.severity != ErrorSeverity.WARNING for e in ing.errors()):\n        ing.start().wait_until_done()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "a1b08239",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from prescient_sdk import IngestResource, LiveStatus\n",
+    "\n",
+    "ing = IngestResource.create(client, spec=Path(\"spec.yaml\"))\n",
+    "with LiveStatus(ing):\n",
+    "    ing.wait_until_ready()\n",
+    "    if not any(e.severity != ErrorSeverity.WARNING for e in ing.errors()):\n",
+    "        ing.start().wait_until_done()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "9deb29bd",
-   "source": "### Attaching to an existing ingestion\n\nUse `IngestionResource.from_id(client, id)` to inspect or resume work on an existing ingestion. Outside a `LiveStatus` block, evaluating an `IngestionResource` in a Jupyter cell renders a static snapshot via `_repr_html_` — which means you can naturally split a workflow across cells: create in one cell, wait under `LiveStatus` in another, inspect in a third.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Attaching to an existing ingestion\n",
+    "\n",
+    "Use `IngestResource.from_id(client, id)` to inspect or resume work on an existing ingestion. Outside a `LiveStatus` block, evaluating an `IngestResource` in a Jupyter cell renders a static snapshot via `_repr_html_` — which means you can naturally split a workflow across cells: create in one cell, wait under `LiveStatus` in another, inspect in a third."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "cb1e9ee0",
-   "source": "ing = IngestionResource.from_id(client, id=42)\ning.refresh()\ning  # rich HTML summary in Jupyter; ANSI table in a terminal",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "cb1e9ee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ing = IngestResource.from_id(client, id=42)\n",
+    "ing.refresh()\n",
+    "ing  # rich HTML summary in Jupyter; ANSI table in a terminal"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "be111715",
-   "source": "### Batches as resources\n\n`IngestionResource.create_batch()` returns a `BatchResource` with the same lifecycle methods (`wait_until_ready`, `start`, `wait_until_done`). Wrap it in `LiveStatus` the same way for a live progress display.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Batches as resources\n",
+    "\n",
+    "`IngestResource.create_batch()` returns a `BatchResource` with the same lifecycle methods (`wait_until_ready`, `start`, `wait_until_done`). Wrap it in `LiveStatus` the same way for a live progress display."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "a1943cd9",
-   "source": "ing = IngestionResource.from_id(client, id=42)\nbatch = ing.create_batch()\n\nwith LiveStatus(batch):\n    batch.wait_until_ready()\n    if not any(e.severity != ErrorSeverity.WARNING for e in batch.errors()):\n        batch.start().wait_until_done()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "a1943cd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ing = IngestResource.from_id(client, id=42)\n",
+    "batch = ing.create_batch()\n",
+    "\n",
+    "with LiveStatus(batch):\n",
+    "    batch.wait_until_ready()\n",
+    "    if not any(e.severity != ErrorSeverity.WARNING for e in batch.errors()):\n",
+    "        batch.start().wait_until_done()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/ingest-resources.rst
+++ b/docs/ingest-resources.rst
@@ -2,6 +2,6 @@ Ingest Resources
 ================
 
 .. automodule:: prescient_sdk.ingest_resources
-    :members: _IngestResource, IngestionResource, BatchResource, LiveStatus
+    :members: _IngestResource, IngestResource, BatchResource, LiveStatus
     :private-members: _IngestResource
     :inherited-members:

--- a/prescient_sdk/__init__.py
+++ b/prescient_sdk/__init__.py
@@ -1,11 +1,11 @@
 from prescient_sdk.client import PrescientClient
 from prescient_sdk.ingest_client import IngestClient
-from prescient_sdk.ingest_resources import BatchResource, IngestionResource, LiveStatus
+from prescient_sdk.ingest_resources import BatchResource, IngestResource, LiveStatus
 
 __all__ = [
     "BatchResource",
     "IngestClient",
-    "IngestionResource",
+    "IngestResource",
     "LiveStatus",
     "PrescientClient",
 ]

--- a/prescient_sdk/config.py
+++ b/prescient_sdk/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     2. `config.env` file: if a `config.env` file is present in the root of the project, it will be used
     """
 
-    prescient_endpoint_url: Optional[str] = Field(
+    prescient_endpoint_url: str = Field(
         description="Base URL of the Prescient API endpoint."
     )
 

--- a/prescient_sdk/ingest_resources.py
+++ b/prescient_sdk/ingest_resources.py
@@ -102,7 +102,7 @@ _RefreshCallback = Callable[["_IngestResource"], None]
 
 
 class _IngestResource:
-    """Shared state + observer machinery for :class:`IngestionResource` and :class:`BatchResource`.
+    """Shared state + observer machinery for :class:`IngestResource` and :class:`BatchResource`.
 
     Subclasses cache a pydantic model, expose status/listings, and notify
     registered observers each time the model changes (via ``refresh()`` or
@@ -219,14 +219,14 @@ class _IngestResource:
         return console.export_html(inline_styles=True)
 
 
-class IngestionResource(_IngestResource):
+class IngestResource(_IngestResource):
     """A Prescient ingestion as a stateful Python resource.
 
     Construct via :meth:`create` (POST a new ingestion) or :meth:`from_id`
     (attach to an existing one). Wrap in :class:`LiveStatus` for a live
     progress display::
 
-        ing = IngestionResource.create(client, spec="spec.yaml")
+        ing = IngestResource.create(client, spec="spec.yaml")
         with LiveStatus(ing):
             ing.wait_until_ready()
             if not ing.errors():
@@ -242,7 +242,7 @@ class IngestionResource(_IngestResource):
     @classmethod
     def create(
         cls, client: IngestClient, spec: Path | str | bytes
-    ) -> "IngestionResource":
+    ) -> "IngestResource":
         """POST a new ingestion from ``spec`` and wrap the result.
 
         Args:
@@ -253,14 +253,14 @@ class IngestionResource(_IngestResource):
                 handled.
 
         Returns:
-            IngestionResource: A resource wrapping the newly created ingestion.
+            IngestResource: A resource wrapping the newly created ingestion.
         """
         ingestion = client.create_ingestion(spec)
-        logger.info("IngestionResource created id=%s", ingestion.id)
+        logger.info("IngestResource created id=%s", ingestion.id)
         return cls(client, ingestion)
 
     @classmethod
-    def from_id(cls, client: IngestClient, id: int) -> "IngestionResource":
+    def from_id(cls, client: IngestClient, id: int) -> "IngestResource":
         """GET an existing ingestion by ID and wrap it.
 
         Args:
@@ -269,7 +269,7 @@ class IngestionResource(_IngestResource):
             id (int): The ingestion's server-assigned ID.
 
         Returns:
-            IngestionResource: A resource wrapping the existing ingestion.
+            IngestResource: A resource wrapping the existing ingestion.
         """
         return cls(client, client.get_ingestion(id))
 
@@ -330,11 +330,11 @@ class IngestionResource(_IngestResource):
 
     # -- State transitions -----------------------------------------------
 
-    def start(self) -> "IngestionResource":
+    def start(self) -> "IngestResource":
         """Start the latest batch (must be ``READY``) and refresh the model.
 
         Returns:
-            IngestionResource: This resource, for chaining.
+            IngestResource: This resource, for chaining.
         """
         logger.info("Starting ingestion id=%s", self.id)
         self._set_model(self._client.start_ingestion(self.id))
@@ -343,7 +343,7 @@ class IngestionResource(_IngestResource):
 
     def wait_until_ready(
         self, poll_interval: float = 5.0, timeout: float = 300.0
-    ) -> "IngestionResource":
+    ) -> "IngestResource":
         """Block until the ingestion enters a ``READY`` (or terminal) state.
 
         Args:
@@ -353,7 +353,7 @@ class IngestionResource(_IngestResource):
                 Defaults to 300.0.
 
         Returns:
-            IngestionResource: This resource, for chaining.
+            IngestResource: This resource, for chaining.
 
         Raises:
             TimeoutError: If ``timeout`` elapses first.
@@ -363,7 +363,7 @@ class IngestionResource(_IngestResource):
 
     def wait_until_done(
         self, poll_interval: float = 10.0, timeout: float = 3600.0
-    ) -> "IngestionResource":
+    ) -> "IngestResource":
         """Block until the ingestion reaches ``DONE``, ``FAILED``, or ``INCOMPLETE``.
 
         Args:
@@ -373,7 +373,7 @@ class IngestionResource(_IngestResource):
                 Defaults to 3600.0.
 
         Returns:
-            IngestionResource: This resource, for chaining.
+            IngestResource: This resource, for chaining.
 
         Raises:
             TimeoutError: If ``timeout`` elapses first.
@@ -446,7 +446,7 @@ class BatchResource(_IngestResource):
 
     Construct via :meth:`create` (POST a new batch under an ingestion) or
     :meth:`from_number` (attach to an existing batch). Most users will get
-    a ``BatchResource`` back from :meth:`IngestionResource.create_batch`.
+    a ``BatchResource`` back from :meth:`IngestResource.create_batch`.
     Wrap in :class:`LiveStatus` for a live progress display.
     """
 
@@ -680,13 +680,13 @@ class BatchResource(_IngestResource):
 class LiveStatus:
     """Render a live, auto-updating Rich display of a resource's status.
 
-    Wraps any :class:`IngestionResource` or :class:`BatchResource`. Use as a
+    Wraps any :class:`IngestResource` or :class:`BatchResource`. Use as a
     context manager — the display starts on ``__enter__``, refreshes after
     every ``refresh()`` and ``start()`` on the wrapped resource, and
     finalizes on ``__exit__``. The resource itself remains fully usable
     outside the block (without the live display)::
 
-        ing = IngestionResource.create(client, spec="spec.yaml")
+        ing = IngestResource.create(client, spec="spec.yaml")
         with LiveStatus(ing):
             ing.wait_until_ready()
             if not ing.errors():

--- a/tests/test_ingest_resources.py
+++ b/tests/test_ingest_resources.py
@@ -1,4 +1,4 @@
-"""Tests for the high-level IngestionResource / BatchResource classes."""
+"""Tests for the high-level IngestResource / BatchResource classes."""
 
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 
 from prescient_sdk import ingest_models as models
 from prescient_sdk.ingest_client import IngestClient
-from prescient_sdk.ingest_resources import BatchResource, IngestionResource, LiveStatus
+from prescient_sdk.ingest_resources import BatchResource, IngestResource, LiveStatus
 
 
 # ---------------------------------------------------------------------------
@@ -89,26 +89,26 @@ def client(mocker: MockerFixture) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# IngestionResource construction
+# IngestResource construction
 # ---------------------------------------------------------------------------
 
 
 def test_ingestion_create_calls_create_ingestion(client):
-    ing = IngestionResource.create(client, spec=b"user: tester\n")
+    ing = IngestResource.create(client, spec=b"user: tester\n")
     client.create_ingestion.assert_called_once_with(b"user: tester\n")
     client.get_ingestion.assert_not_called()
     assert ing.id == 1
 
 
 def test_ingestion_from_id_calls_get_ingestion(client):
-    ing = IngestionResource.from_id(client, id=42)
+    ing = IngestResource.from_id(client, id=42)
     client.get_ingestion.assert_called_once_with(42)
     client.create_ingestion.assert_not_called()
     assert ing.id == 1  # from the mock's return value
 
 
 # ---------------------------------------------------------------------------
-# IngestionResource properties & listings
+# IngestResource properties & listings
 # ---------------------------------------------------------------------------
 
 
@@ -116,14 +116,14 @@ def test_ingestion_properties_delegate_to_model(client):
     client.create_ingestion.return_value = make_ingestion_model(
         id=7, status="READY", user="alice"
     )
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     assert ing.id == 7
     assert ing.status is models.Status.READY
     assert ing.spec["user"] == "alice"
 
 
 def test_ingestion_listings_call_through(client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     ing.input_files()
     ing.output_files()
     ing.errors()
@@ -133,12 +133,12 @@ def test_ingestion_listings_call_through(client):
 
 
 # ---------------------------------------------------------------------------
-# IngestionResource lifecycle
+# IngestResource lifecycle
 # ---------------------------------------------------------------------------
 
 
 def test_ingestion_refresh_updates_status_and_errors(client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     # After construction the status is SCANNING; switch the mock to READY.
     client.get_ingestion.return_value = make_ingestion_model(id=1, status="READY")
     client.get_ingestion_errors.return_value = [make_error_model()]
@@ -150,7 +150,7 @@ def test_ingestion_refresh_updates_status_and_errors(client):
 
 
 def test_ingestion_start_updates_state(client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     ing.start()
     client.start_ingestion.assert_called_once_with(1)
     assert ing.status is models.Status.INGESTING
@@ -159,7 +159,7 @@ def test_ingestion_start_updates_state(client):
 def test_ingestion_wait_until_ready_polls_until_target(
     mocker: MockerFixture, client
 ):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     # Two SCANNING polls, then READY.
     client.get_ingestion.side_effect = [
         make_ingestion_model(status="SCANNING"),
@@ -179,7 +179,7 @@ def test_ingestion_wait_until_ready_polls_until_target(
 def test_ingestion_wait_until_done_targets_done_failed_incomplete(
     mocker: MockerFixture, client
 ):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     # READY should NOT terminate wait_until_done — it should keep polling.
     client.get_ingestion.side_effect = [
         make_ingestion_model(status="READY"),
@@ -193,7 +193,7 @@ def test_ingestion_wait_until_done_targets_done_failed_incomplete(
 
 
 def test_ingestion_wait_times_out(mocker: MockerFixture, client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     client.get_ingestion.return_value = make_ingestion_model(status="SCANNING")
     mocker.patch("prescient_sdk.ingest_client.time.sleep")
     # Force monotonic to jump past the deadline on first check.
@@ -207,12 +207,12 @@ def test_ingestion_wait_times_out(mocker: MockerFixture, client):
 
 
 # ---------------------------------------------------------------------------
-# IngestionResource batches
+# IngestResource batches
 # ---------------------------------------------------------------------------
 
 
 def test_ingestion_create_batch_returns_batch_resource(client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     client.create_batch.return_value = make_batch_model(
         ingestion_id=1, batch_number=2
     )
@@ -228,7 +228,7 @@ def test_ingestion_list_batches_returns_wrappers(client):
         make_batch_model(batch_number=1),
         make_batch_model(batch_number=2),
     ]
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
 
     batches = ing.list_batches()
     assert len(batches) == 2
@@ -245,7 +245,7 @@ def test_live_status_starts_and_stops_live(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     with LiveStatus(ing) as scope:
         assert scope is ing
         live_instance.start.assert_called_once()
@@ -259,7 +259,7 @@ def test_live_status_updates_on_refresh(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     with LiveStatus(ing):
         # Each refresh should fire the observer and update the live display.
         ing.refresh()
@@ -273,7 +273,7 @@ def test_live_status_unsubscribes_on_exit(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     with LiveStatus(ing):
         pass
 
@@ -289,7 +289,7 @@ def test_live_status_stops_live_even_if_refresh_fails(
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     # The first call (in create) succeeded; make the next refresh raise.
     client.get_ingestion.side_effect = RuntimeError("network down")
 
@@ -303,7 +303,7 @@ def test_live_status_does_not_swallow_exceptions(
     mocker: MockerFixture, client
 ):
     mocker.patch("prescient_sdk.ingest_resources.Live")
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
 
     with pytest.raises(RuntimeError, match="user code"):
         with LiveStatus(ing):
@@ -320,7 +320,7 @@ def test_render_produces_non_empty_renderable(client):
     import io
     from rich.console import Console
 
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     buf = io.StringIO()
     Console(file=buf, force_terminal=True, width=120).print(ing)
     out = buf.getvalue()
@@ -333,7 +333,7 @@ def test_repr_html_contains_status_and_id(client):
     client.create_ingestion.return_value = make_ingestion_model(
         id=99, status="DONE", user="alice"
     )
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     html = ing._repr_html_()
     assert isinstance(html, str)
     assert "#99" in html
@@ -341,7 +341,7 @@ def test_repr_html_contains_status_and_id(client):
 
 
 def test_render_includes_error_panel_when_errors_present(client):
-    ing = IngestionResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=b"")
     client.get_ingestion_errors.return_value = [
         make_error_model(severity="CRITICAL", description="boom"),
     ]


### PR DESCRIPTION
- Makes `prescient_endpoint_url` a required field. Previously `Optional[str]` without a default value resulted in errors when attempting to access the value later.
- Refactor `IngestionResource` to `IngestResource`.