### PR TITLE
feat: add IngestSpec value object (#59)

### DIFF
--- a/prescient_sdk/__init__.py
+++ b/prescient_sdk/__init__.py
@@ -1,11 +1,13 @@
 from prescient_sdk.client import PrescientClient
 from prescient_sdk.ingest_client import IngestClient
 from prescient_sdk.ingest_resources import BatchResource, IngestResource, LiveStatus
+from prescient_sdk.ingest_spec import IngestSpec
 
 __all__ = [
     "BatchResource",
     "IngestClient",
     "IngestResource",
+    "IngestSpec",
     "LiveStatus",
     "PrescientClient",
 ]

--- a/prescient_sdk/ingest_resources.py
+++ b/prescient_sdk/ingest_resources.py
@@ -242,17 +242,15 @@ class IngestResource(_IngestResource):
 
     @classmethod
     def create(
-        cls, client: IngestClient, spec: Path | str | bytes | IngestSpec
+        cls, client: IngestClient, spec: IngestSpec
     ) -> "IngestResource":
         """POST a new ingestion from ``spec`` and wrap the result.
 
         Args:
             client (IngestClient): Client used for the API call and subsequent
                 state transitions.
-            spec (Path | str | bytes | IngestSpec): The specification to submit.
-                A ``Path``/``str``/``bytes`` is passed through to
-                :meth:`IngestClient.create_ingestion` unchanged. An
-                :class:`~prescient_sdk.ingest_spec.IngestSpec` is serialized to
+            spec (IngestSpec): The specification to submit.
+                A :class:`~prescient_sdk.ingest_spec.IngestSpec` is serialized to
                 YAML and submitted, but only after checking that every location
                 is an ``s3://`` path — the Ingest API cannot read local paths.
 
@@ -264,6 +262,9 @@ class IngestResource(_IngestResource):
                 locations still pointing at a local (non-``s3://``) path. Upload
                 those sources first (see ``IngestSpec.with_uploaded_sources``).
         """
+        if any(isinstance(spec, invalid_type) for invalid_type in (str, Path, bytes)):
+            raise ValueError(f"Expected IngestSpec, got {type(spec)}")
+
         if isinstance(spec, IngestSpec):
             local = spec.local_locations()
             if local:
@@ -272,6 +273,7 @@ class IngestResource(_IngestResource):
                     f"paths and must be uploaded first: {local}"
                 )
             spec = spec.to_bytes()
+
         ingestion = client.create_ingestion(spec)
         logger.info("IngestResource created id=%s", ingestion.id)
         return cls(client, ingestion)

--- a/prescient_sdk/ingest_resources.py
+++ b/prescient_sdk/ingest_resources.py
@@ -28,6 +28,7 @@ from rich.text import Text
 
 from prescient_sdk import ingest_models as models
 from prescient_sdk.ingest_client import IngestClient, _poll_for_status
+from prescient_sdk.ingest_spec import IngestSpec
 from prescient_sdk.ingest_models import (
     DONE_STATUSES,
     READY_STATUSES,
@@ -241,20 +242,36 @@ class IngestResource(_IngestResource):
 
     @classmethod
     def create(
-        cls, client: IngestClient, spec: Path | str | bytes
+        cls, client: IngestClient, spec: Path | str | bytes | IngestSpec
     ) -> "IngestResource":
         """POST a new ingestion from ``spec`` and wrap the result.
 
         Args:
             client (IngestClient): Client used for the API call and subsequent
                 state transitions.
-            spec (Path | str | bytes): The YAML specification. See
-                :meth:`IngestClient.create_ingestion` for how each type is
-                handled.
+            spec (Path | str | bytes | IngestSpec): The specification to submit.
+                A ``Path``/``str``/``bytes`` is passed through to
+                :meth:`IngestClient.create_ingestion` unchanged. An
+                :class:`~prescient_sdk.ingest_spec.IngestSpec` is serialized to
+                YAML and submitted, but only after checking that every location
+                is an ``s3://`` path — the Ingest API cannot read local paths.
 
         Returns:
             IngestResource: A resource wrapping the newly created ingestion.
+
+        Raises:
+            ValueError: If ``spec`` is an :class:`IngestSpec` with one or more
+                locations still pointing at a local (non-``s3://``) path. Upload
+                those sources first (see ``IngestSpec.with_uploaded_sources``).
         """
+        if isinstance(spec, IngestSpec):
+            local = spec.local_locations()
+            if local:
+                raise ValueError(
+                    "Cannot create an ingestion: these locations have non-s3:// "
+                    f"paths and must be uploaded first: {local}"
+                )
+            spec = spec.to_bytes()
         ingestion = client.create_ingestion(spec)
         logger.info("IngestResource created id=%s", ingestion.id)
         return cls(client, ingestion)
@@ -398,8 +415,7 @@ class IngestResource(_IngestResource):
             list[BatchResource]: One resource per batch in this ingestion.
         """
         return [
-            BatchResource(self._client, m)
-            for m in self._client.list_batches(self.id)
+            BatchResource(self._client, m) for m in self._client.list_batches(self.id)
         ]
 
     # -- Internals -------------------------------------------------------
@@ -432,7 +448,9 @@ class IngestResource(_IngestResource):
         spec_table.add_row("User", str(spec.get("user", "—")))
         spec_table.add_row("Tasks", str(len(spec.get("tasks") or {})))
         spec_table.add_row("Locations", str(len(spec.get("locations") or {})))
-        spec_table.add_row("Source file sets", str(len(spec.get("source_file_sets") or {})))
+        spec_table.add_row(
+            "Source file sets", str(len(spec.get("source_file_sets") or {}))
+        )
 
         renderables: list[RenderableType] = [header, spec_table]
         errs_panel = _errors_panel(self._errors)
@@ -566,9 +584,7 @@ class BatchResource(_IngestResource):
         Returns:
             list[OutputFile]: Output files produced by this batch.
         """
-        return self._client.get_batch_output_files(
-            self.ingestion_id, self.batch_number
-        )
+        return self._client.get_batch_output_files(self.ingestion_id, self.batch_number)
 
     def errors(self) -> list[Error]:
         """Fetch the errors recorded against this batch.
@@ -589,9 +605,7 @@ class BatchResource(_IngestResource):
         logger.info(
             "Starting batch ingestion=%s batch=%s", self.ingestion_id, self.batch_number
         )
-        self._set_model(
-            self._client.start_batch(self.ingestion_id, self.batch_number)
-        )
+        self._set_model(self._client.start_batch(self.ingestion_id, self.batch_number))
         self._notify()
         return self
 
@@ -708,9 +722,7 @@ class LiveStatus:
         )
 
     def __enter__(self) -> _IngestResource:
-        logger.debug(
-            "LiveStatus started for %s", self._resource.__class__.__name__
-        )
+        logger.debug("LiveStatus started for %s", self._resource.__class__.__name__)
         self._live.start()
         self._resource.on_refresh(self._on_refresh)
         return self._resource

--- a/prescient_sdk/ingest_spec.py
+++ b/prescient_sdk/ingest_spec.py
@@ -42,7 +42,7 @@ class IngestSpec:
     """
 
     def __init__(self, spec: dict[str, Any]):
-        self._spec = spec
+        self._spec = spec 
 
     @classmethod
     def from_file(cls, path: Path | str) -> "IngestSpec":
@@ -90,6 +90,15 @@ class IngestSpec:
             )
         return cls(copy.deepcopy(spec))
 
+    @classmethod
+    def from_bytes(cls, spec: bytes) -> "IngestSpec":
+        """IngestSpec from bytes"""
+        if not isinstance(spec, bytes):
+            raise ValueError(
+                    f"Ingestion spec must be bytes, got{type(spec).__name__}"
+                    )
+        return cls(yaml.safe_load(spec))
+
     @property
     def spec(self) -> dict[str, Any]:
         """A deep copy of the parsed spec.
@@ -124,7 +133,7 @@ class IngestSpec:
         Returns:
             list[str]: Location names with a non-``s3://`` path, in spec order.
         """
-        locations = self._spec.get("locations") or {}
+        locations = {} if self._spec is None else self._spec.get("locations", {})
         return [
             name
             for name, location in locations.items()

--- a/prescient_sdk/ingest_spec.py
+++ b/prescient_sdk/ingest_spec.py
@@ -1,0 +1,132 @@
+"""The :class:`IngestSpec` value object.
+
+An :class:`IngestSpec` is a parsed ingestion specification (the YAML document
+describing an ingestion's ``locations``, ``source_files``, ``tasks`` and STAC
+metadata). It is the typed entry point for building an ingestion from Python.
+
+The Ingest API only accepts ``s3://`` location paths. A spec authored locally may
+still point a location at a local directory; uploading those sources and
+rewriting their paths (staging) is a separate step. This class carries the parsed
+spec, serializes it for submission, and can report which locations are still
+local so callers can refuse to submit an unstaged spec.
+
+`IngestSpec` is immutable: there are no methods that change a spec in place.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("prescient_sdk")
+
+
+class IngestSpec:
+    """A parsed ingestion specification.
+
+    Construct via :meth:`from_file` or :meth:`from_dict` so the parse step is
+    visible at the call site. Use :meth:`to_bytes` to serialize the spec for
+    submission, and :meth:`local_locations` to check whether any location still
+    points at a local (non-``s3://``) path.
+
+    Example::
+
+        spec = IngestSpec.from_file("spec.yaml")
+        if spec.local_locations():
+            raise RuntimeError("upload local sources before ingesting")
+        ing = IngestResource.create(client, spec)
+    """
+
+    def __init__(self, spec: dict[str, Any]):
+        self._spec = spec
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> "IngestSpec":
+        """Parse an ingestion specification from a YAML file.
+
+        Args:
+            path (Path | str): Path to the spec YAML file.
+
+        Returns:
+            IngestSpec: The parsed spec.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            ValueError: If the file does not contain a YAML mapping.
+        """
+        path = Path(path)
+        with open(path) as fh:
+            parsed = yaml.safe_load(fh)
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Ingestion spec at {path} must be a YAML mapping, got {type(parsed).__name__}"
+            )
+        logger.debug("Parsed ingestion spec from %s", path)
+        return cls(parsed)
+
+    @classmethod
+    def from_dict(cls, spec: dict[str, Any]) -> "IngestSpec":
+        """Wrap an already-parsed spec dict.
+
+        The dict is copied, so later mutations of the caller's dict do not affect
+        this spec.
+
+        Args:
+            spec (dict[str, Any]): The ingestion specification.
+
+        Returns:
+            IngestSpec: The wrapped spec.
+
+        Raises:
+            ValueError: If ``spec`` is not a mapping.
+        """
+        if not isinstance(spec, dict):
+            raise ValueError(
+                f"Ingestion spec must be a mapping, got {type(spec).__name__}"
+            )
+        return cls(copy.deepcopy(spec))
+
+    @property
+    def spec(self) -> dict[str, Any]:
+        """A deep copy of the parsed spec.
+
+        A copy is returned so callers cannot mutate the spec through this
+        accessor; :class:`IngestSpec` is immutable.
+
+        Returns:
+            dict[str, Any]: A copy of the spec.
+        """
+        return copy.deepcopy(self._spec)
+
+    def to_bytes(self) -> bytes:
+        """Serialize the spec back to YAML bytes for submission.
+
+        Key order is preserved so the serialized form matches the authored spec.
+
+        Returns:
+            bytes: The UTF-8 encoded YAML document, suitable for
+            :meth:`prescient_sdk.ingest_client.IngestClient.create_ingestion`.
+        """
+        return yaml.safe_dump(self._spec, sort_keys=False).encode("utf-8")
+
+    def local_locations(self) -> list[str]:
+        """Return the names of locations whose path is not an ``s3://`` URI.
+
+        The Ingest API only reads ``s3://`` locations, so a non-empty result
+        means the spec is not ready to submit (its local sources must be uploaded
+        and their paths rewritten first). A location with no ``path`` is also
+        reported, since it cannot be read either.
+
+        Returns:
+            list[str]: Location names with a non-``s3://`` path, in spec order.
+        """
+        locations = self._spec.get("locations") or {}
+        return [
+            name
+            for name, location in locations.items()
+            if not str((location or {}).get("path", "")).startswith("s3://")
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "msal>=1.31.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.5.2",
+    "pyyaml>=6.0.3",
     "requests>=2.32.3",
     "rich>=13.0",
 ]

--- a/tests/test_ingest_resources.py
+++ b/tests/test_ingest_resources.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture
 from prescient_sdk import ingest_models as models
 from prescient_sdk.ingest_client import IngestClient
 from prescient_sdk.ingest_resources import BatchResource, IngestResource, LiveStatus
+from prescient_sdk.ingest_spec import IngestSpec
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +108,29 @@ def test_ingestion_from_id_calls_get_ingestion(client):
     assert ing.id == 1  # from the mock's return value
 
 
+def test_ingestion_create_accepts_ingest_spec(client):
+    spec = IngestSpec.from_dict(
+        {"user": "tester", "locations": {"src": {"path": "s3://bucket/data"}}}
+    )
+    ing = IngestResource.create(client, spec)
+    client.create_ingestion.assert_called_once_with(spec.to_bytes())
+    assert ing.id == 1
+
+
+def test_ingestion_create_rejects_local_locations_in_spec(client):
+    spec = IngestSpec.from_dict(
+        {
+            "locations": {
+                "src": {"path": "/mnt/data/scenes"},
+                "target": {"path": "s3://bucket"},
+            }
+        }
+    )
+    with pytest.raises(ValueError, match="src"):
+        IngestResource.create(client, spec)
+    client.create_ingestion.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # IngestResource properties & listings
 # ---------------------------------------------------------------------------
@@ -156,9 +180,7 @@ def test_ingestion_start_updates_state(client):
     assert ing.status is models.Status.INGESTING
 
 
-def test_ingestion_wait_until_ready_polls_until_target(
-    mocker: MockerFixture, client
-):
+def test_ingestion_wait_until_ready_polls_until_target(mocker: MockerFixture, client):
     ing = IngestResource.create(client, spec=b"")
     # Two SCANNING polls, then READY.
     client.get_ingestion.side_effect = [
@@ -213,9 +235,7 @@ def test_ingestion_wait_times_out(mocker: MockerFixture, client):
 
 def test_ingestion_create_batch_returns_batch_resource(client):
     ing = IngestResource.create(client, spec=b"")
-    client.create_batch.return_value = make_batch_model(
-        ingestion_id=1, batch_number=2
-    )
+    client.create_batch.return_value = make_batch_model(ingestion_id=1, batch_number=2)
 
     batch = ing.create_batch()
     assert isinstance(batch, BatchResource)
@@ -283,9 +303,7 @@ def test_live_status_unsubscribes_on_exit(mocker: MockerFixture, client):
     live_instance.update.assert_not_called()
 
 
-def test_live_status_stops_live_even_if_refresh_fails(
-    mocker: MockerFixture, client
-):
+def test_live_status_stops_live_even_if_refresh_fails(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
@@ -299,9 +317,7 @@ def test_live_status_stops_live_even_if_refresh_fails(
     live_instance.stop.assert_called_once()
 
 
-def test_live_status_does_not_swallow_exceptions(
-    mocker: MockerFixture, client
-):
+def test_live_status_does_not_swallow_exceptions(mocker: MockerFixture, client):
     mocker.patch("prescient_sdk.ingest_resources.Live")
     ing = IngestResource.create(client, spec=b"")
 

--- a/tests/test_ingest_resources.py
+++ b/tests/test_ingest_resources.py
@@ -95,7 +95,8 @@ def client(mocker: MockerFixture) -> MagicMock:
 
 
 def test_ingestion_create_calls_create_ingestion(client):
-    ing = IngestResource.create(client, spec=b"user: tester\n")
+    spec = IngestSpec.from_bytes(spec=b"user: tester\n")
+    ing = IngestResource.create(client, spec=spec)
     client.create_ingestion.assert_called_once_with(b"user: tester\n")
     client.get_ingestion.assert_not_called()
     assert ing.id == 1
@@ -140,14 +141,14 @@ def test_ingestion_properties_delegate_to_model(client):
     client.create_ingestion.return_value = make_ingestion_model(
         id=7, status="READY", user="alice"
     )
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     assert ing.id == 7
     assert ing.status is models.Status.READY
     assert ing.spec["user"] == "alice"
 
 
 def test_ingestion_listings_call_through(client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     ing.input_files()
     ing.output_files()
     ing.errors()
@@ -162,7 +163,7 @@ def test_ingestion_listings_call_through(client):
 
 
 def test_ingestion_refresh_updates_status_and_errors(client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     # After construction the status is SCANNING; switch the mock to READY.
     client.get_ingestion.return_value = make_ingestion_model(id=1, status="READY")
     client.get_ingestion_errors.return_value = [make_error_model()]
@@ -174,14 +175,14 @@ def test_ingestion_refresh_updates_status_and_errors(client):
 
 
 def test_ingestion_start_updates_state(client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     ing.start()
     client.start_ingestion.assert_called_once_with(1)
     assert ing.status is models.Status.INGESTING
 
 
 def test_ingestion_wait_until_ready_polls_until_target(mocker: MockerFixture, client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     # Two SCANNING polls, then READY.
     client.get_ingestion.side_effect = [
         make_ingestion_model(status="SCANNING"),
@@ -201,7 +202,7 @@ def test_ingestion_wait_until_ready_polls_until_target(mocker: MockerFixture, cl
 def test_ingestion_wait_until_done_targets_done_failed_incomplete(
     mocker: MockerFixture, client
 ):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     # READY should NOT terminate wait_until_done — it should keep polling.
     client.get_ingestion.side_effect = [
         make_ingestion_model(status="READY"),
@@ -215,7 +216,7 @@ def test_ingestion_wait_until_done_targets_done_failed_incomplete(
 
 
 def test_ingestion_wait_times_out(mocker: MockerFixture, client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     client.get_ingestion.return_value = make_ingestion_model(status="SCANNING")
     mocker.patch("prescient_sdk.ingest_client.time.sleep")
     # Force monotonic to jump past the deadline on first check.
@@ -234,7 +235,7 @@ def test_ingestion_wait_times_out(mocker: MockerFixture, client):
 
 
 def test_ingestion_create_batch_returns_batch_resource(client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     client.create_batch.return_value = make_batch_model(ingestion_id=1, batch_number=2)
 
     batch = ing.create_batch()
@@ -248,7 +249,7 @@ def test_ingestion_list_batches_returns_wrappers(client):
         make_batch_model(batch_number=1),
         make_batch_model(batch_number=2),
     ]
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
 
     batches = ing.list_batches()
     assert len(batches) == 2
@@ -265,7 +266,7 @@ def test_live_status_starts_and_stops_live(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     with LiveStatus(ing) as scope:
         assert scope is ing
         live_instance.start.assert_called_once()
@@ -279,7 +280,7 @@ def test_live_status_updates_on_refresh(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     with LiveStatus(ing):
         # Each refresh should fire the observer and update the live display.
         ing.refresh()
@@ -293,7 +294,7 @@ def test_live_status_unsubscribes_on_exit(mocker: MockerFixture, client):
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     with LiveStatus(ing):
         pass
 
@@ -307,7 +308,7 @@ def test_live_status_stops_live_even_if_refresh_fails(mocker: MockerFixture, cli
     live_cls = mocker.patch("prescient_sdk.ingest_resources.Live")
     live_instance = live_cls.return_value
 
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     # The first call (in create) succeeded; make the next refresh raise.
     client.get_ingestion.side_effect = RuntimeError("network down")
 
@@ -319,7 +320,7 @@ def test_live_status_stops_live_even_if_refresh_fails(mocker: MockerFixture, cli
 
 def test_live_status_does_not_swallow_exceptions(mocker: MockerFixture, client):
     mocker.patch("prescient_sdk.ingest_resources.Live")
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
 
     with pytest.raises(RuntimeError, match="user code"):
         with LiveStatus(ing):
@@ -336,7 +337,7 @@ def test_render_produces_non_empty_renderable(client):
     import io
     from rich.console import Console
 
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     buf = io.StringIO()
     Console(file=buf, force_terminal=True, width=120).print(ing)
     out = buf.getvalue()
@@ -349,7 +350,7 @@ def test_repr_html_contains_status_and_id(client):
     client.create_ingestion.return_value = make_ingestion_model(
         id=99, status="DONE", user="alice"
     )
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     html = ing._repr_html_()
     assert isinstance(html, str)
     assert "#99" in html
@@ -357,7 +358,7 @@ def test_repr_html_contains_status_and_id(client):
 
 
 def test_render_includes_error_panel_when_errors_present(client):
-    ing = IngestResource.create(client, spec=b"")
+    ing = IngestResource.create(client, spec=IngestSpec.from_bytes(b""))
     client.get_ingestion_errors.return_value = [
         make_error_model(severity="CRITICAL", description="boom"),
     ]

--- a/tests/test_ingest_spec.py
+++ b/tests/test_ingest_spec.py
@@ -1,0 +1,99 @@
+"""Tests for the IngestSpec value object."""
+
+import textwrap
+
+import pytest
+import yaml
+
+from prescient_sdk.ingest_spec import IngestSpec
+
+
+SPEC = {
+    "user": "tester",
+    "locations": {
+        "source_location": {"path": "s3://source-bucket/data"},
+        "target_location": {"path": "s3://target-bucket"},
+    },
+    "source_files": {
+        "enhanced": {"location": "source_location", "pattern": r".*\.tif$"},
+    },
+}
+
+
+def test_from_dict_copies_input():
+    original = {"locations": {"a": {"path": "s3://b/x"}}}
+    spec = IngestSpec.from_dict(original)
+    original["locations"]["a"]["path"] = "mutated"
+    assert spec.spec["locations"]["a"]["path"] == "s3://b/x"
+
+
+def test_from_dict_rejects_non_mapping():
+    with pytest.raises(ValueError):
+        IngestSpec.from_dict(["not", "a", "mapping"])
+
+
+def test_from_file_parses_yaml(tmp_path):
+    path = tmp_path / "spec.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            user: tester
+            locations:
+              source_location:
+                path: s3://source-bucket/data
+            """
+        )
+    )
+    spec = IngestSpec.from_file(path)
+    assert spec.spec["user"] == "tester"
+    assert (
+        spec.spec["locations"]["source_location"]["path"] == "s3://source-bucket/data"
+    )
+
+
+def test_from_file_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        IngestSpec.from_file(tmp_path / "nope.yaml")
+
+
+def test_from_file_non_mapping_raises(tmp_path):
+    path = tmp_path / "spec.yaml"
+    path.write_text("- just\n- a\n- list\n")
+    with pytest.raises(ValueError):
+        IngestSpec.from_file(path)
+
+
+def test_spec_accessor_returns_copy():
+    spec = IngestSpec.from_dict(SPEC)
+    spec.spec["user"] = "mutated"
+    assert spec.spec["user"] == "tester"
+
+
+def test_to_bytes_round_trips_and_preserves_order():
+    spec = IngestSpec.from_dict(SPEC)
+    reparsed = yaml.safe_load(spec.to_bytes())
+    assert reparsed == SPEC
+    # user was authored first; sort_keys=False must preserve that
+    assert list(reparsed.keys())[0] == "user"
+
+
+def test_local_locations_flags_non_s3():
+    spec = IngestSpec.from_dict(
+        {
+            "locations": {
+                "remote": {"path": "s3://bucket/data"},
+                "local_dir": {"path": "/mnt/data/scenes"},
+                "file_uri": {"path": "file:///mnt/data"},
+                "missing_path": {},
+            }
+        }
+    )
+    assert spec.local_locations() == ["local_dir", "file_uri", "missing_path"]
+
+
+def test_local_locations_empty_when_all_s3():
+    assert IngestSpec.from_dict(SPEC).local_locations() == []
+
+
+def test_local_locations_no_locations_key():
+    assert IngestSpec.from_dict({"user": "tester"}).local_locations() == []

--- a/uv.lock
+++ b/uv.lock
@@ -3761,6 +3761,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pydantic-settings", version = "2.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "rich" },
@@ -3797,6 +3798,7 @@ requires-dist = [
     { name = "msal", specifier = ">=1.31.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.5.2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rich", specifier = ">=13.0" },
 ]


### PR DESCRIPTION
## Summary

Implements #59 — the first slice of the end-to-end ingest workflow (parent #56).

Adds `IngestSpec`, a parsed, immutable ingestion specification that is the typed entry point for building an ingestion from Python, and teaches `IngestResource.create` to accept it.

## What's included

- **`prescient_sdk/ingest_spec.py`** — `IngestSpec`:
  - `from_file(path)` / `from_dict(spec)` parse the spec (via `yaml.safe_load`).
  - `.spec` returns a deep copy (immutable); `.to_bytes()` serializes back to YAML with key order preserved.
  - `local_locations()` reports locations whose `path` is not an `s3://` URI
- **`IngestResource.create`** now accepts `Path | str | bytes | IngestSpec`. For an `IngestSpec` it raises `ValueError` (naming the offending locations) if any location is still local; otherwise it submits `.to_bytes()`. Raw `bytes`/`str`/`Path` inputs are unchanged.
- **`pyyaml`** promoted to a runtime dependency; `IngestSpec` exported from `prescient_sdk`.

Staging (uploading local sources + rewriting their paths) is intentionally **out of scope** here — that's #61 (blocked by this and #60).

## Acceptance criteria

- [x] `IngestSpec.from_file` / `from_dict` parse a spec; `.to_bytes()` round-trips
- [x] `IngestResource.create` accepts an all-`s3://` `IngestSpec` and submits the serialized spec
- [x] `create` raises `ValueError` naming the offending location when an `IngestSpec` has a non-`s3://` location path
- [x] `pyyaml` declared as a runtime dependency; `IngestSpec` exported from `prescient_sdk`
- [x] Unit tests cover parse, round-trip, create-with-`IngestSpec`, and the guardrail

## Testing

- `uv run pytest` — 124 passed
- `uv run ruff check prescient_sdk/ tests/` — clean; files formatted with `ruff format`

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
