### PR TITLE
feat: add pattern-filtered staging upload helper (#60)

### DIFF
--- a/prescient_sdk/config.py
+++ b/prescient_sdk/config.py
@@ -116,6 +116,14 @@ class Settings(BaseSettings):
         default=None,
         description="Optional AWS S3 bucket name targeted by the upload helpers.",
     )
+    prescient_upload_prefix: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional key prefix under `prescient_upload_bucket` for staged source "
+            "files (e.g. 'user-uploads'). When unset, staged files are keyed from the "
+            "bucket root."
+        ),
+    )
 
     model_config = SettingsConfigDict(
         env_file="config.env",

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from collections.abc import Iterator
 from pathlib import Path, PurePath
-from typing import Optional
+from typing import Callable, Optional
 
 import boto3
 import botocore.exceptions
@@ -81,6 +82,111 @@ def _make_s3_key(file: Path, root: Path) -> str:
     root_name = root.name or root.resolve().name
     relative_part = file.relative_to(root).as_posix()
     return f"{root_name}/{relative_part}"
+
+
+def _split_s3_uri(uri: str) -> tuple[str, str]:
+    """Split an ``s3://bucket/key/prefix`` URI into ``(bucket, key_prefix)``.
+
+    The returned key prefix is normalized to end with ``/`` (unless empty) so
+    it can be concatenated directly with a relative path to form an object key.
+
+    Args:
+        uri (str): An ``s3://`` URI.
+
+    Returns:
+        tuple[str, str]: The bucket name and the (possibly empty) key prefix.
+
+    Raises:
+        ValueError: If ``uri`` is not an ``s3://`` URI or has no bucket.
+    """
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Destination must be an s3:// URI, got {uri!r}")
+    bucket, _, key_prefix = uri[len("s3://") :].partition("/")
+    if not bucket:
+        raise ValueError(f"Destination s3:// URI is missing a bucket: {uri!r}")
+    if key_prefix and not key_prefix.endswith("/"):
+        key_prefix += "/"
+    return bucket, key_prefix
+
+
+def upload_source_files(
+    local_dir: str | os.PathLike,
+    dest_prefix: str,
+    pattern: str,
+    session: boto3.Session,
+    on_file: Optional[Callable[[int, int, Path], None]] = None,
+    overwrite: bool = True,
+) -> None:
+    """Upload the files under ``local_dir`` that a source file set's pattern selects.
+
+    Only files whose path *relative to* ``local_dir`` matches ``pattern`` are
+    uploaded, and each is written to ``dest_prefix`` + that same relative path —
+    verbatim, with no directory-name segment injected. This preserves every
+    file's path relative to its location, so the spec's ``pattern`` still matches
+    after the files move to S3 (the Ingest API strips the location prefix and
+    applies ``re.match`` to the remaining relative path).
+
+    ``pattern`` is applied with ``re.match`` (anchored at the start of the
+    relative path), matching the Ingest API's own file selection.
+
+    Example::
+
+        session = prescient_client.upload_session
+        upload_source_files(
+            "/data/scenes",
+            "s3://uploads/user-uploads/3f9.../",
+            r".*\\.tif$",
+            session,
+        )
+
+    Args:
+        local_dir (str | os.PathLike): Local directory to scan recursively.
+        dest_prefix (str): Destination ``s3://bucket/key/prefix/`` URI. Uploaded
+            keys are ``dest_prefix`` joined with each file's relative path.
+        pattern (str): Regex applied (``re.match``) to each file's posix path
+            relative to ``local_dir``.
+        session (boto3.Session): AWS session authorized to write to the bucket
+            (typically ``PrescientClient.upload_session``).
+        on_file (Callable[[int, int, Path], None], optional): Called after each
+            upload with ``(index, total, path)`` where ``index`` is 1-based.
+            Useful for progress display. Defaults to None.
+        overwrite (bool, optional): When False, skip files that already exist at
+            the destination key. Defaults to True.
+
+    Raises:
+        FileNotFoundError: If ``local_dir`` does not exist.
+        ValueError: If ``dest_prefix`` is not a valid ``s3://`` URI.
+    """
+    local_path = Path(local_dir)
+    if not local_path.exists():
+        raise FileNotFoundError(local_dir)
+
+    bucket, key_prefix = _split_s3_uri(dest_prefix)
+    regex = re.compile(pattern)
+    matched = [
+        file
+        for file in iter_files(local_path)
+        if regex.match(file.relative_to(local_path).as_posix())
+    ]
+    total = len(matched)
+    logger.info(
+        "staging %s file(s) matching %r from %s to %s",
+        total,
+        pattern,
+        local_path,
+        dest_prefix,
+    )
+    for index, file in enumerate(matched, start=1):
+        relative = file.relative_to(local_path).as_posix()
+        _upload(
+            file=str(file),
+            bucket=bucket,
+            key=key_prefix + relative,
+            session=session,
+            overwrite=overwrite,
+        )
+        if on_file is not None:
+            on_file(index, total, file)
 
 
 def upload(

--- a/prescient_sdk/upload.py
+++ b/prescient_sdk/upload.py
@@ -109,6 +109,24 @@ def _split_s3_uri(uri: str) -> tuple[str, str]:
     return bucket, key_prefix
 
 
+def _relative_posix(file: PurePath, root: PurePath) -> str:
+    """Return ``file``'s path relative to ``root`` using forward slashes.
+
+    ``as_posix`` normalizes separators so S3 keys and pattern matching are
+    identical on Windows and POSIX — e.g. a Windows ``nested\\image.tif``
+    becomes ``nested/image.tif``. S3 keys always use ``/``, so the local OS
+    separator must never leak into a key.
+
+    Args:
+        file (PurePath): The file path, under ``root``.
+        root (PurePath): The directory ``file`` is relative to.
+
+    Returns:
+        str: The forward-slash relative path.
+    """
+    return file.relative_to(root).as_posix()
+
+
 def upload_source_files(
     local_dir: str | os.PathLike,
     dest_prefix: str,
@@ -166,7 +184,7 @@ def upload_source_files(
     matched = [
         file
         for file in iter_files(local_path)
-        if regex.match(file.relative_to(local_path).as_posix())
+        if regex.match(_relative_posix(file, local_path))
     ]
     total = len(matched)
     logger.info(
@@ -177,11 +195,10 @@ def upload_source_files(
         dest_prefix,
     )
     for index, file in enumerate(matched, start=1):
-        relative = file.relative_to(local_path).as_posix()
         _upload(
             file=str(file),
             bucket=bucket,
-            key=key_prefix + relative,
+            key=key_prefix + _relative_posix(file, local_path),
             session=session,
             overwrite=overwrite,
         )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,5 +1,5 @@
 import time
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import boto3
 import pytest
@@ -8,6 +8,7 @@ from moto import mock_aws
 from prescient_sdk.client import PrescientClient
 from prescient_sdk.upload import (
     _make_s3_key,
+    _relative_posix,
     _split_s3_uri,
     iter_files,
     upload,
@@ -221,3 +222,43 @@ def test_upload_source_files_missing_dir(tmp_path):
         upload_source_files(
             tmp_path / "nope", "s3://test-bucket/p/", ".*", boto3.Session()
         )
+
+
+def test_relative_posix_windows_style():
+    root = PureWindowsPath(r"C:\data\scenes")
+    file = PureWindowsPath(r"C:\data\scenes\nested\image.tif")
+    assert _relative_posix(file, root) == "nested/image.tif"
+
+
+def test_relative_posix_posix_style():
+    root = PurePosixPath("/data/scenes")
+    file = PurePosixPath("/data/scenes/nested/image.tif")
+    assert _relative_posix(file, root) == "nested/image.tif"
+
+
+def test_staged_key_from_windows_path_uses_forward_slashes():
+    # The staged S3 key is key_prefix + relative posix path; a Windows source
+    # tree must still produce forward-slash keys (S3 keys never use backslashes).
+    root = PureWindowsPath(r"C:\data\scenes")
+    file = PureWindowsPath(r"C:\data\scenes\a\b\image.tif")
+
+    key = "user-uploads/uid/" + _relative_posix(file, root)
+
+    assert key == "user-uploads/uid/a/b/image.tif"
+    assert "\\" not in key
+
+
+def test_upload_source_files_windows_pattern_matches_relative_posix(
+    tmp_path, s3, create_test_bucket
+):
+    # A pattern written with a forward-slash subdirectory (as authored in a spec)
+    # must match nested files regardless of the local OS separator, because
+    # matching runs on the posix relative path.
+    _make_tree(tmp_path, ["a/scene.tif", "b/scene.tif", "a/note.txt"])
+
+    upload_source_files(tmp_path, "s3://test-bucket/p/", r"a/.*\.tif$", boto3.Session())
+
+    keys = sorted(
+        o["Key"] for o in s3.list_objects_v2(Bucket="test-bucket")["Contents"]
+    )
+    assert keys == ["p/a/scene.tif"]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,11 +1,25 @@
 import time
 from pathlib import Path, PureWindowsPath
 
+import boto3
 import pytest
 from moto import mock_aws
 
 from prescient_sdk.client import PrescientClient
-from prescient_sdk.upload import _make_s3_key, iter_files, upload
+from prescient_sdk.upload import (
+    _make_s3_key,
+    _split_s3_uri,
+    iter_files,
+    upload,
+    upload_source_files,
+)
+
+
+def _make_tree(root: Path, rel_paths: list[str]) -> None:
+    for rel in rel_paths:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
 
 
 @pytest.fixture
@@ -138,3 +152,72 @@ def test_upload_invalid_dir(tmp_path):
     tmp_dir = tmp_path.joinpath("some-dir")
     with pytest.raises(FileNotFoundError):
         upload(str(tmp_dir))
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    [
+        ("s3://bucket/a/b/", ("bucket", "a/b/")),
+        ("s3://bucket/a/b", ("bucket", "a/b/")),
+        ("s3://bucket/", ("bucket", "")),
+        ("s3://bucket", ("bucket", "")),
+    ],
+)
+def test_split_s3_uri(uri, expected):
+    assert _split_s3_uri(uri) == expected
+
+
+@pytest.mark.parametrize("uri", ["http://bucket/x", "bucket/x", "s3://", "s3:///key"])
+def test_split_s3_uri_invalid(uri):
+    with pytest.raises(ValueError):
+        _split_s3_uri(uri)
+
+
+def test_upload_source_files_filters_and_preserves_relative_paths(
+    tmp_path, s3, create_test_bucket
+):
+    _make_tree(tmp_path, ["a.tif", "sub/b.tif", "note.txt"])
+    calls = []
+
+    upload_source_files(
+        tmp_path,
+        "s3://test-bucket/user-uploads/uid/",
+        r".*\.tif$",
+        boto3.Session(),
+        on_file=lambda index, total, path: calls.append((index, total, path)),
+    )
+
+    keys = sorted(
+        o["Key"] for o in s3.list_objects_v2(Bucket="test-bucket")["Contents"]
+    )
+    # only .tif files, keyed as dest_prefix + relative path (no dir-name segment)
+    assert keys == ["user-uploads/uid/a.tif", "user-uploads/uid/sub/b.tif"]
+    assert all(tmp_path.name not in key for key in keys)
+    # on_file fired once per uploaded file with a 1-based index and the total
+    assert [(index, total) for index, total, _ in calls] == [(1, 2), (2, 2)]
+    assert {path for _, _, path in calls} == {
+        tmp_path / "a.tif",
+        tmp_path / "sub" / "b.tif",
+    }
+
+
+def test_upload_source_files_uses_anchored_match(tmp_path, s3, create_test_bucket):
+    # re.match anchors at the start: "scene.tif" matches at the root but not
+    # under a subdirectory, so only the root file is selected.
+    _make_tree(tmp_path, ["scene.tif", "sub/scene.tif"])
+
+    upload_source_files(
+        tmp_path, "s3://test-bucket/p/", r"scene\.tif$", boto3.Session()
+    )
+
+    keys = sorted(
+        o["Key"] for o in s3.list_objects_v2(Bucket="test-bucket")["Contents"]
+    )
+    assert keys == ["p/scene.tif"]
+
+
+def test_upload_source_files_missing_dir(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        upload_source_files(
+            tmp_path / "nope", "s3://test-bucket/p/", ".*", boto3.Session()
+        )


### PR DESCRIPTION
## Summary

Implements #60 — the staging upload helper for the end-to-end ingest workflow (parent #56).

Adds `upload_source_files`, which uploads only the local files a source file set's `pattern` selects, preserving each file's path relative to its location so the spec's `pattern` keeps matching after the files move to S3.

## What's included

- **`prescient_sdk/upload.py`**:
  - `upload_source_files(local_dir, dest_prefix, pattern, session, on_file=None, overwrite=True)` — selects files whose posix path *relative to* `local_dir` matches `pattern` (anchored `re.match`, matching the Ingest API's own selection), and uploads each to `dest_prefix` + that relative path **verbatim**. It deliberately does **not** inject the local directory name into the key (that would shift relative paths and break pattern matching). Reuses the existing `iter_files` and `_upload`. The `on_file(index, total, path)` callback enables progress display without coupling the upload layer to Rich.
  - `_split_s3_uri` — parses an `s3://bucket/key/prefix` URI into `(bucket, key_prefix)`.
- **`prescient_sdk/config.py`** — optional `prescient_upload_prefix` setting for composing destination prefixes under the upload bucket.

`dest_prefix` is a full `s3://…` URI so the same value can be reused as the rewritten `location.path` when staging an `IngestSpec` (#61) — one source of truth for where files land and where the spec points.

## Acceptance criteria

- [x] Helper uploads only files matching the pattern (anchored, relative posix path); non-matching files skipped
- [x] Object keys are exactly `{dest_prefix}{relative_path}` with no injected directory-name segment
- [x] `on_file` callback fires once per uploaded file with `(index, total, path)`
- [x] `prescient_upload_prefix` added to settings (optional)
- [x] moto-backed tests assert the uploaded key set and the `re.match` semantics

## Testing

- `uv run pytest` — 123 passed
- `uv run ruff check prescient_sdk/ tests/` — clean; files formatted with `ruff format`

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
